### PR TITLE
Feature/adding platform support

### DIFF
--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -242,7 +242,17 @@ jobs:
           BUILDX_PUSH_PRODUCTION_COMMAND="docker buildx build --push --platform=${{ inputs.platforms }} $COMMON"
           echo "BUILDX_PUSH_PRODUCTION_COMMAND=$BUILDX_PUSH_PRODUCTION_COMMAND" >> $GITHUB_OUTPUT
 
+          ## Note this is only needed as buildx doesnt support --load with multiple platforms yet but is on roadmap
+          ## if it is ever supported simply remove this and the "Load test oci image step" and add --load to the first BUILD_TEST_COMMAND
+          BUILDX_LOAD_PRODUCTION_COMMAND="docker buildx build --load $COMMON -t app:production ."
+          echo "BUILDX_LOAD_PRODUCTION_COMMAND=$BUILDX_LOAD_PRODUCTION_COMMAND" >> $GITHUB_OUTPUT
+
           DOCKER_BUILDKIT=1 $BUILD_PRODUCTION_COMMAND
+
+      - name: Load Production OCI Image
+        if: steps.env2.outputs.USE_BUILDX == 'true'
+        id: load-test
+        run: $(${{ steps.build-production.outputs.BUILDX_LOAD_PRODUCTION_COMMAND }})
 
       - name: Task ${{ inputs.production_build_task_1_name }}
         if: inputs.production_build_task_1 != ''

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -17,18 +17,22 @@ on:
       default_branch:
         default: "master"
         type: string
+      ## if not set defaults to default_branch
       default_branch_for_caching:
         default: ""
         type: string
+      ## if not set defaults to default_branch
       default_develop_branch:
         default: ""
         type: string
       version_command:
         default: "cat .ruby-version"
         type: string
+      ## if not set defaults to ecr_repository
       projects:
         default: ""
         type: string
+      ## if not set will use docker build, if set will use buildx
       platforms:
         default: ""
         type: string

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -173,7 +173,7 @@ jobs:
           docker pull ${{ steps.env2.outputs.IMAGE_ID }}:cache || echo "true"
           COMMAND=""
           if [ "${{ inputs.platforms }}" != "" ]; then
-            COMMAND="docker buildx --platform=\"${{ inputs.platforms }}\" --load "
+            COMMAND="docker buildx build --platform=\"${{ inputs.platforms }}\" --load "
           else
             COMMAND="DOCKER_BUILDKIT=1 docker build --build-arg BUILDKIT_INLINE_CACHE=1"
           fi
@@ -203,7 +203,7 @@ jobs:
         run: |
           COMMAND=""
           if [ "${{ inputs.platforms }}" != "" ]; then
-            COMMAND="docker buildx --platforms=\"${{ inputs.platforms }}\" --load "
+            COMMAND="docker buildx build --platform=\"${{ inputs.platforms }}\" --load "
           else
             COMMAND="DOCKER_BUILDKIT=1 docker build --build-arg BUILDKIT_INLINE_CACHE=1"
           fi

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -278,7 +278,7 @@ jobs:
           if [ "${{ steps.env2.outputs.USE_BUILDX }}" == "true" ]; then
             $(${{ steps.build-test.outputs.BUILDX_PUSH_PRODUCTION_COMMAND }})
           else 
-            docker push ${{ steps.env2.outputs.IMAGE_ID }}:cache
+            docker push ${{ steps.env2.outputs.IMAGE_ID }}:${{ steps.env1.outputs.IMAGE_TAG }}
           fi
 
       - name: Push cache to ECR

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -251,7 +251,7 @@ jobs:
 
       - name: Load Production OCI Image
         if: steps.env2.outputs.USE_BUILDX == 'true'
-        id: load-test
+        id: load-production
         run: $(${{ steps.build-production.outputs.BUILDX_LOAD_PRODUCTION_COMMAND }})
 
       - name: Task ${{ inputs.production_build_task_1_name }}

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -180,13 +180,13 @@ jobs:
       - name: Build Test OCI Image
         id: build-test
         run: |
-          docker pull ${{ steps.env2.outputs.IMAGE_ID }}:cache || echo "true"
           BUILD_TEST_COMMAND=""
           COMMON="--target development --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.IMAGE_ID }}:cache "
 
           if [ "${{ inputs.platforms }}" != "" ]; then
             BUILD_TEST_COMMAND="docker buildx build --platform=${{ inputs.platforms }} $COMMON -t app:cache ."
           else
+            docker pull ${{ steps.env2.outputs.IMAGE_ID }}:cache || echo "true"
             BUILD_TEST_COMMAND="DOCKER_BUILDKIT=1 docker build $COMMON -t ${{ steps.env2.outputs.IMAGE_ID }}:cache -t app:cache ."
           fi
 

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -166,6 +166,14 @@ jobs:
             DEFAULT_BRANCH_FOR_CACHING="${{ inputs.default_branch }}"
           fi
           echo "DEFAULT_BRANCH_FOR_CACHING=$DEFAULT_BRANCH_FOR_CACHING" >> $GITHUB_OUTPUT
+      
+      - name: Set up QEMU
+        if: inputs.platforms != ''
+        uses: docker/setup-qemu-action@v1
+
+      - name: Set up Docker Buildx
+        if: inputs.platforms != ''
+        uses: docker/setup-buildx-action@v1
 
       - name: Build Test OCI Image
         id: build-test

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -172,22 +172,19 @@ jobs:
           if [ "${{ inputs.platforms }}" != "" ]; then
             USE_BUILDX="true"
           fi
-          echo "$USE_BUILDX"
-
           echo "USE_BUILDX=$USE_BUILDX" >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
-        if: ${{ steps.env2.outputs.USE_BUILDX }} == 'true'
+        if: steps.env2.outputs.USE_BUILDX == 'true'
         uses: docker/setup-qemu-action@v1
 
       - name: Set up Docker Buildx
-        if: ${{ steps.env2.outputs.USE_BUILDX }} == 'true'
+        if: steps.env2.outputs.USE_BUILDX == 'true'
         uses: docker/setup-buildx-action@v1
 
       - name: Build Test OCI Image
         id: build-test
         run: |
-          echo "$USE_BUILDX"
           BUILD_TEST_COMMAND=""
           COMMON="--target development --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.IMAGE_ID }}:cache "
 
@@ -209,7 +206,7 @@ jobs:
           DOCKER_BUILDKIT=1 $BUILD_TEST_COMMAND
 
       - name: Load Test OCI Image
-        if: ${{ steps.env2.outputs.USE_BUILDX }} == 'true'
+        if: steps.env2.outputs.USE_BUILDX == 'true'
         id: load-test
         run: $(${{ steps.build-test.outputs.BUILDX_LOAD_TEST_COMMAND }})
 

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -173,7 +173,7 @@ jobs:
           docker pull ${{ steps.env2.outputs.IMAGE_ID }}:cache || echo "true"
           COMMAND=""
           if [ "${{ inputs.platforms }}" != "" ]; then
-            COMMAND="docker buildx --platforms=\"${{ inputs.platforms }}\" --load "
+            COMMAND="docker buildx --platform=\"${{ inputs.platforms }}\" --load "
           else
             COMMAND="DOCKER_BUILDKIT=1 docker build --build-arg BUILDKIT_INLINE_CACHE=1"
           fi

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -173,7 +173,7 @@ jobs:
           docker pull ${{ steps.env2.outputs.IMAGE_ID }}:cache || echo "true"
           COMMAND=""
           if [ "${{ inputs.platforms }}" != "" ]; then
-            COMMAND="docker buildx build --platform=\"${{ inputs.platforms }}\" --load "
+            COMMAND="docker buildx build --platform=${{ inputs.platforms }} --load "
           else
             COMMAND="DOCKER_BUILDKIT=1 docker build --build-arg BUILDKIT_INLINE_CACHE=1"
           fi
@@ -203,7 +203,7 @@ jobs:
         run: |
           COMMAND=""
           if [ "${{ inputs.platforms }}" != "" ]; then
-            COMMAND="docker buildx build --platform=\"${{ inputs.platforms }}\" --load "
+            COMMAND="docker buildx build --platform=${{ inputs.platforms }} --load "
           else
             COMMAND="DOCKER_BUILDKIT=1 docker build --build-arg BUILDKIT_INLINE_CACHE=1"
           fi

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -168,13 +168,18 @@ jobs:
             DEFAULT_BRANCH_FOR_CACHING="${{ inputs.default_branch }}"
           fi
           echo "DEFAULT_BRANCH_FOR_CACHING=$DEFAULT_BRANCH_FOR_CACHING" >> $GITHUB_OUTPUT
+          USE_BUILDX="false"
+          if [ "${{ inputs.platforms }}" != "" ]; then
+            USE_BUILDX="true"
+          fi
+          echo "USE_BUILDX=$(${{ inputs.platforms }}" >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
-        if: inputs.platforms != ''
+        if: ${{ steps.env2.outputs.USE_BUILDX }} == 'true'
         uses: docker/setup-qemu-action@v1
 
       - name: Set up Docker Buildx
-        if: inputs.platforms != ''
+        if: ${{ steps.env2.outputs.USE_BUILDX }} == 'true'
         uses: docker/setup-buildx-action@v1
 
       - name: Build Test OCI Image
@@ -183,7 +188,7 @@ jobs:
           BUILD_TEST_COMMAND=""
           COMMON="--target development --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.IMAGE_ID }}:cache "
 
-          if [ "${{ inputs.platforms }}" != "" ]; then
+          if [ "${{ steps.env2.outputs.USE_BUILDX }}" == "true" ]; then
             BUILD_TEST_COMMAND="docker buildx build --platform=${{ inputs.platforms }} $COMMON -t app:cache ."
           else
             docker pull ${{ steps.env2.outputs.IMAGE_ID }}:cache || echo "true"
@@ -201,7 +206,7 @@ jobs:
           $($BUILD_TEST_COMMAND)
 
       - name: Load Test OCI Image
-        if: inputs.platforms != ''
+        if: ${{ steps.env2.outputs.USE_BUILDX }} == 'true'
         id: load-test
         run: $(${{ steps.build-test.outputs.BUILDX_LOAD_TEST_COMMAND }})
 
@@ -228,7 +233,7 @@ jobs:
         run: |
           BUILD_PRODUCTION_COMMAND=""
           COMMON="--target production --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg RELEASE_VERSION=${{ steps.env1.outputs.IMAGE_TAG }} --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.IMAGE_ID }}:cache -t ${{ steps.env2.outputs.IMAGE_ID }}:${{ steps.env1.outputs.IMAGE_TAG }} ."
-          if [ "${{ inputs.platforms }}" != "" ]; then
+          if [ "${{ steps.env2.outputs.USE_BUILDX }}" == "true" ]; then
             BUILD_PRODUCTION_COMMAND="docker buildx build --platform=${{ inputs.platforms }} $COMMON"
           else
             BUILD_PRODUCTION_COMMAND="DOCKER_BUILDKIT=1 docker build $COMMON"
@@ -260,7 +265,7 @@ jobs:
       - name: Push to ECR
         if: (inputs.event_name == 'push' && steps.env1.outputs.BRANCH_NAME == inputs.default_branch) ||  inputs.event_name == 'issue_comment' || (steps.env1.outputs.BRANCH_NAME == inputs.default_develop_branch &&  inputs.event_name == 'push')
         run: |
-          if [ "${{ inputs.platforms }}" != "" ]; then
+          if [ "${{ steps.env2.outputs.USE_BUILDX }}" == "true" ]; then
             $(${{ steps.build-test.outputs.BUILDX_PUSH_PRODUCTION_COMMAND }})
           else 
             docker push ${{ steps.env2.outputs.IMAGE_ID }}:cache
@@ -269,7 +274,7 @@ jobs:
       - name: Push cache to ECR
         if: (inputs.event_name == 'push' && steps.env1.outputs.BRANCH_NAME == steps.env2.outputs.DEFAULT_BRANCH_FOR_CACHING)
         run: |
-          if [ "${{ inputs.platforms }}" != "" ]; then
+          if [ "${{ steps.env2.outputs.USE_BUILDX }}" == "true" ]; then
             $(${{ steps.build-test.outputs.BUILDX_PUSH_TEST_COMMAND }})
           else
             docker push ${{ steps.env2.outputs.IMAGE_ID }}:cache

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -276,7 +276,7 @@ jobs:
         if: (inputs.event_name == 'push' && steps.env1.outputs.BRANCH_NAME == inputs.default_branch) ||  inputs.event_name == 'issue_comment' || (steps.env1.outputs.BRANCH_NAME == inputs.default_develop_branch &&  inputs.event_name == 'push')
         run: |
           if [ "${{ steps.env2.outputs.USE_BUILDX }}" == "true" ]; then
-            $(${{ steps.build-test.outputs.BUILDX_PUSH_PRODUCTION_COMMAND }})
+            $(${{ steps.build-production.outputs.BUILDX_PUSH_PRODUCTION_COMMAND }})
           else 
             docker push ${{ steps.env2.outputs.IMAGE_ID }}:${{ steps.env1.outputs.IMAGE_TAG }}
           fi

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -172,7 +172,7 @@ jobs:
           if [ "${{ inputs.platforms }}" != "" ]; then
             USE_BUILDX="true"
           fi
-          echo "USE_BUILDX=$(${{ inputs.platforms }}" >> $GITHUB_OUTPUT
+          echo "USE_BUILDX="$USE_BUILDX" >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
         if: ${{ steps.env2.outputs.USE_BUILDX }} == 'true'

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -178,6 +178,7 @@ jobs:
             COMMAND="DOCKER_BUILDKIT=1 docker build --build-arg BUILDKIT_INLINE_CACHE=1"
           fi
           COMMAND="$COMMAND --target development --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.IMAGE_ID }}:cache -t ${{ steps.env2.outputs.IMAGE_ID }}:cache -t app:cache ."
+          echo "$COMMAND"
           $($COMMAND)
 
       - name: Task ${{ inputs.extra_task_1_name }}

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -189,7 +189,7 @@ jobs:
           COMMON="--target development --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.IMAGE_ID }}:cache "
 
           if [ "${{ steps.env2.outputs.USE_BUILDX }}" == "true" ]; then
-            BUILD_TEST_COMMAND="docker buildx build --platform=${{ inputs.platforms }} $COMMON -t app:cache ."
+            BUILD_TEST_COMMAND="docker buildx build --platform=${{ inputs.platforms }} $COMMON -t ${{ steps.env2.outputs.IMAGE_ID }}:cache -t app:cache ."
           else
             docker pull ${{ steps.env2.outputs.IMAGE_ID }}:cache || echo "true"
             BUILD_TEST_COMMAND="DOCKER_BUILDKIT=1 docker build $COMMON -t ${{ steps.env2.outputs.IMAGE_ID }}:cache -t app:cache ."

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -166,7 +166,7 @@ jobs:
             DEFAULT_BRANCH_FOR_CACHING="${{ inputs.default_branch }}"
           fi
           echo "DEFAULT_BRANCH_FOR_CACHING=$DEFAULT_BRANCH_FOR_CACHING" >> $GITHUB_OUTPUT
-      
+
       - name: Set up QEMU
         if: inputs.platforms != ''
         uses: docker/setup-qemu-action@v1
@@ -183,9 +183,9 @@ jobs:
           if [ "${{ inputs.platforms }}" != "" ]; then
             COMMAND="docker buildx build --platform=${{ inputs.platforms }} --load "
           else
-            COMMAND="DOCKER_BUILDKIT=1 docker build --build-arg BUILDKIT_INLINE_CACHE=1"
+            COMMAND="DOCKER_BUILDKIT=1 docker build"
           fi
-          COMMAND="$COMMAND --target development --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.IMAGE_ID }}:cache -t ${{ steps.env2.outputs.IMAGE_ID }}:cache -t app:cache ."
+          COMMAND="$COMMAND --target development --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.IMAGE_ID }}:cache -t ${{ steps.env2.outputs.IMAGE_ID }}:cache -t app:cache ."
           echo "$COMMAND"
           $($COMMAND)
 
@@ -214,9 +214,9 @@ jobs:
           if [ "${{ inputs.platforms }}" != "" ]; then
             COMMAND="docker buildx build --platform=${{ inputs.platforms }} --load "
           else
-            COMMAND="DOCKER_BUILDKIT=1 docker build --build-arg BUILDKIT_INLINE_CACHE=1"
+            COMMAND="DOCKER_BUILDKIT=1 docker build"
           fi
-          COMMAND="$COMMAND --target production --build-arg RELEASE_VERSION=${{ steps.env1.outputs.IMAGE_TAG }} --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.IMAGE_ID }}:cache -t ${{ steps.env2.outputs.IMAGE_ID }}:${{ steps.env1.outputs.IMAGE_TAG }} ."
+          COMMAND="$COMMAND --target production --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg RELEASE_VERSION=${{ steps.env1.outputs.IMAGE_TAG }} --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.IMAGE_ID }}:cache -t ${{ steps.env2.outputs.IMAGE_ID }}:${{ steps.env1.outputs.IMAGE_TAG }} ."
           $($COMMAND)
 
       - name: Task ${{ inputs.production_build_task_1_name }}

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -170,9 +170,10 @@ jobs:
           echo "DEFAULT_BRANCH_FOR_CACHING=$DEFAULT_BRANCH_FOR_CACHING" >> $GITHUB_OUTPUT
           USE_BUILDX="false"
           if [ "${{ inputs.platforms }}" != "" ]; then
-            echo "hello?"
             USE_BUILDX="true"
           fi
+          echo "$USE_BUILDX"
+
           echo "USE_BUILDX=$USE_BUILDX" >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
@@ -186,6 +187,7 @@ jobs:
       - name: Build Test OCI Image
         id: build-test
         run: |
+          echo "$USE_BUILDX"
           BUILD_TEST_COMMAND=""
           COMMON="--target development --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.IMAGE_ID }}:cache "
 

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -178,7 +178,7 @@ jobs:
             COMMAND="DOCKER_BUILDKIT=1 docker build --build-arg BUILDKIT_INLINE_CACHE=1"
           fi
           COMMAND="$COMMAND --target development --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.IMAGE_ID }}:cache -t ${{ steps.env2.outputs.IMAGE_ID }}:cache -t app:cache ."
-          $(COMMAND)
+          $($COMMAND)
 
       - name: Task ${{ inputs.extra_task_1_name }}
         if: inputs.extra_task_1 != ''
@@ -208,7 +208,7 @@ jobs:
             COMMAND="DOCKER_BUILDKIT=1 docker build --build-arg BUILDKIT_INLINE_CACHE=1"
           fi
           COMMAND="$COMMAND --target production --build-arg RELEASE_VERSION=${{ steps.env1.outputs.IMAGE_TAG }} --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.IMAGE_ID }}:cache -t ${{ steps.env2.outputs.IMAGE_ID }}:${{ steps.env1.outputs.IMAGE_TAG }} ."
-          $(COMMAND)
+          $($COMMAND)
 
       - name: Task ${{ inputs.production_build_task_1_name }}
         if: inputs.production_build_task_1 != ''

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -179,15 +179,21 @@ jobs:
         id: build-test
         run: |
           docker pull ${{ steps.env2.outputs.IMAGE_ID }}:cache || echo "true"
-          COMMAND=""
+          BUILD_TEST_COMMAND=""
+
           if [ "${{ inputs.platforms }}" != "" ]; then
-            COMMAND="docker buildx build --platform=${{ inputs.platforms }} --load "
+            BUILD_TEST_COMMAND="docker buildx build --platform=${{ inputs.platforms }} --target development --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.IMAGE_ID }}:cache -t app:cache ."
           else
-            COMMAND="DOCKER_BUILDKIT=1 docker build"
+            BUILD_TEST_COMMAND="DOCKER_BUILDKIT=1 docker build --target development --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.IMAGE_ID }}:cache -t ${{ steps.env2.outputs.IMAGE_ID }}:cache -t app:cache ."
           fi
-          COMMAND="$COMMAND --target development --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.IMAGE_ID }}:cache -t ${{ steps.env2.outputs.IMAGE_ID }}:cache -t app:cache ."
-          echo "$COMMAND"
-          $($COMMAND)
+
+          BUILDX_PUSH_TEST_COMMAND="docker buildx build --platform=${{ inputs.platforms }} --target development --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.IMAGE_ID }}:cache -t ${{ steps.env2.outputs.IMAGE_ID }}:cache ."
+          echo "BUILDX_PUSH_TEST_COMMAND=$BUILDX_PUSH_TEST_COMMAND" >> $GITHUB_OUTPUT
+
+          $($BUILD_TEST_COMMAND)
+          if [ "${{ inputs.platforms }}" != "" ]; then
+            docker buildx build --load --target development --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.IMAGE_ID }}:cache -t app:cache .
+          fi
 
       - name: Task ${{ inputs.extra_task_1_name }}
         if: inputs.extra_task_1 != ''
@@ -210,14 +216,17 @@ jobs:
       - name: Build Production OCI Image
         id: build-production
         run: |
-          COMMAND=""
+          BUILD_PRODUCTION_COMMAND=""
           if [ "${{ inputs.platforms }}" != "" ]; then
-            COMMAND="docker buildx build --platform=${{ inputs.platforms }} --load "
+            BUILD_PRODUCTION_COMMAND="docker buildx build --platform=${{ inputs.platforms }} --target production --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg RELEASE_VERSION=${{ steps.env1.outputs.IMAGE_TAG }} --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.IMAGE_ID }}:cache -t ${{ steps.env2.outputs.IMAGE_ID }}:${{ steps.env1.outputs.IMAGE_TAG }} ."
           else
-            COMMAND="DOCKER_BUILDKIT=1 docker build"
+            BUILD_PRODUCTION_COMMAND="DOCKER_BUILDKIT=1 docker build --target production --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg RELEASE_VERSION=${{ steps.env1.outputs.IMAGE_TAG }} --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.IMAGE_ID }}:cache -t ${{ steps.env2.outputs.IMAGE_ID }}:${{ steps.env1.outputs.IMAGE_TAG }} ."
           fi
-          COMMAND="$COMMAND --target production --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg RELEASE_VERSION=${{ steps.env1.outputs.IMAGE_TAG }} --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.IMAGE_ID }}:cache -t ${{ steps.env2.outputs.IMAGE_ID }}:${{ steps.env1.outputs.IMAGE_TAG }} ."
-          $($COMMAND)
+
+          BUILDX_PUSH_PRODUCTION_COMMAND="docker buildx build --push --platform=${{ inputs.platforms }} --target production --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg RELEASE_VERSION=${{ steps.env1.outputs.IMAGE_TAG }} --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.IMAGE_ID }}:cache -t ${{ steps.env2.outputs.IMAGE_ID }}:${{ steps.env1.outputs.IMAGE_TAG }} ."
+          echo "BUILDX_PUSH_PRODUCTION_COMMAND=$BUILDX_PUSH_PRODUCTION_COMMAND" >> $GITHUB_OUTPUT
+
+          $($BUILD_PRODUCTION_COMMAND)
 
       - name: Task ${{ inputs.production_build_task_1_name }}
         if: inputs.production_build_task_1 != ''
@@ -240,12 +249,20 @@ jobs:
       - name: Push to ECR
         if: (inputs.event_name == 'push' && steps.env1.outputs.BRANCH_NAME == inputs.default_branch) ||  inputs.event_name == 'issue_comment' || (steps.env1.outputs.BRANCH_NAME == inputs.default_develop_branch &&  inputs.event_name == 'push')
         run: |
-          docker push ${{ steps.env2.outputs.IMAGE_ID }}:${{ steps.env1.outputs.IMAGE_TAG }}
+          if [ "${{ inputs.platforms }}" != "" ]; then
+            $(${{ steps.build-test.outputs.BUILDX_PUSH_PRODUCTION_COMMAND }})
+          else 
+            docker push ${{ steps.env2.outputs.IMAGE_ID }}:cache
+          fi
 
       - name: Push cache to ECR
         if: (inputs.event_name == 'push' && steps.env1.outputs.BRANCH_NAME == steps.env2.outputs.DEFAULT_BRANCH_FOR_CACHING)
         run: |
-          docker push ${{ steps.env2.outputs.IMAGE_ID }}:cache
+          if [ "${{ inputs.platforms }}" != "" ]; then
+            $(${{ steps.build-test.outputs.BUILDX_PUSH_TEST_COMMAND }})
+          else
+            docker push ${{ steps.env2.outputs.IMAGE_ID }}:cache
+          fi
 
       - name: Update GitOps Repo to trigger deploys
         if: steps.env1.outputs.BRANCH_NAME == inputs.default_branch &&  inputs.event_name == 'push'

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -6,7 +6,7 @@ on:
         required: true
         type: string
       dev_url:
-        required: true
+        default: ""
         type: string
       event_name:
         required: true
@@ -18,13 +18,16 @@ on:
         default: "master"
         type: string
       default_branch_for_caching:
-        default: "master"
+        default: ""
         type: string
       default_develop_branch:
         default: ""
         type: string
       version_command:
         default: "cat .ruby-version"
+        type: string
+      projects:
+        default: ""
         type: string
       platforms:
         default: ""
@@ -145,6 +148,7 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: |
           DOCKER_ECR=${{ secrets.DOCKER_ECR }}
+          echo "DOCKER_ECR=$DOCKER_ECR" >> $GITHUB_ENV
           VERSION=$(${{ inputs.version_command }})
           BASE_IMAGE="${DOCKER_ECR}ruby-base:${VERSION}"
           echo "BASE_IMAGE=$BASE_IMAGE" >> $GITHUB_OUTPUT
@@ -152,52 +156,75 @@ jobs:
           IMAGE_ID=$(echo "$ECR_REGISTRY/${{ inputs.ecr_repository }}" | tr '[A-Z]' '[a-z]')
           echo "ECR_REGISTRY=$ECR_REGISTRY" >> $GITHUB_OUTPUT
           echo "IMAGE_ID=$IMAGE_ID" >> $GITHUB_OUTPUT
+          PROJECTS="${{ inputs.ecr_repository }}"
+          if [ "${{ inputs.projects }}" != "" ]; then
+            PROJECTS="${{ inputs.projects }}"
+          fi
+          echo "PROJECTS=$PROJECTS" >> $GITHUB_OUTPUT
+          DEFAULT_BRANCH_FOR_CACHING="${{ inputs.default_branch_for_caching }}"
+          if [ "$DEFAULT_BRANCH_FOR_CACHING" == "" ]; then
+            DEFAULT_BRANCH_FOR_CACHING="${{ inputs.default_branch }}"
+          fi
+          echo "DEFAULT_BRANCH_FOR_CACHING=$DEFAULT_BRANCH_FOR_CACHING" >> $GITHUB_OUTPUT
 
       - name: Build Test OCI Image
         id: build-test
         run: |
           docker pull ${{ steps.env2.outputs.IMAGE_ID }}:cache || echo "true"
-          DOCKER_BUILDKIT=1 docker build --target development \
-          --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }} \
-          --build-arg BUILDKIT_INLINE_CACHE=1 \
-          --cache-from ${{ steps.env2.outputs.IMAGE_ID }}:cache \
-          -t ${{ steps.env2.outputs.IMAGE_ID }}:cache \
-          -t app:cache .
+          COMMAND=""
+          if [ "${{ inputs.platforms }}" != "" ]; then
+            COMMAND="docker buildx --platforms=\"${{ inputs.platforms }}\" --load "
+          else
+            COMMAND="DOCKER_BUILDKIT=1 docker build --build-arg BUILDKIT_INLINE_CACHE=1"
+          fi
+          COMMAND="$COMMAND --target development --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.IMAGE_ID }}:cache -t ${{ steps.env2.outputs.IMAGE_ID }}:cache -t app:cache ."
+          $(COMMAND)
 
       - name: Task ${{ inputs.extra_task_1_name }}
         if: inputs.extra_task_1 != ''
+        id: extra-task-1
         run: |
           ${{ inputs.extra_task_1 }}
 
       - name: Task ${{ inputs.extra_task_2_name }}
         if: inputs.extra_task_2 != ''
+        id: extra-task-2
         run: |
           ${{ inputs.extra_task_2 }}
 
       - name: Task ${{ inputs.extra_task_3_name }}
         if: inputs.extra_task_3 != ''
+        id: extra-task-3
         run: |
           ${{ inputs.extra_task_3 }}
 
       - name: Build Production OCI Image
+        id: build-production
         run: |
-          DOCKER_BUILDKIT=1 docker build --cache-from ${{ steps.env2.outputs.IMAGE_ID }}:cache \
-          --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }} \
-          --build-arg RELEASE_VERSION=${{ steps.env1.outputs.IMAGE_TAG }} \
-          -t ${{ steps.env2.outputs.IMAGE_ID }}:${{ steps.env1.outputs.IMAGE_TAG }} .
+          COMMAND=""
+          if [ "${{ inputs.platforms }}" != "" ]; then
+            COMMAND="docker buildx --platforms=\"${{ inputs.platforms }}\" --load "
+          else
+            COMMAND="DOCKER_BUILDKIT=1 docker build --build-arg BUILDKIT_INLINE_CACHE=1"
+          fi
+          COMMAND="$COMMAND --target production --build-arg RELEASE_VERSION=${{ steps.env1.outputs.IMAGE_TAG }} --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.IMAGE_ID }}:cache -t ${{ steps.env2.outputs.IMAGE_ID }}:${{ steps.env1.outputs.IMAGE_TAG }} ."
+          $(COMMAND)
 
       - name: Task ${{ inputs.production_build_task_1_name }}
         if: inputs.production_build_task_1 != ''
+        id: production-extra-task-1
         run: |
           ${{ inputs.production_build_task_1 }}
 
       - name: Task ${{ inputs.production_build_task_2_name }}
         if: inputs.production_build_task_2 != ''
+        id: production-extra-task-2
         run: |
           ${{ inputs.production_build_task_2 }}
 
       - name: Task ${{ inputs.production_build_task_3_name }}
         if: inputs.production_build_task_3 != ''
+        id: production-extra-task-3
         run: |
           ${{ inputs.production_build_task_3 }}
 
@@ -207,7 +234,7 @@ jobs:
           docker push ${{ steps.env2.outputs.IMAGE_ID }}:${{ steps.env1.outputs.IMAGE_TAG }}
 
       - name: Push cache to ECR
-        if: (inputs.event_name == 'push' && steps.env1.outputs.BRANCH_NAME == inputs.default_branch)
+        if: (inputs.event_name == 'push' && steps.env1.outputs.BRANCH_NAME == steps.env2.outputs.DEFAULT_BRANCH_FOR_CACHING)
         run: |
           docker push ${{ steps.env2.outputs.IMAGE_ID }}:cache
 
@@ -216,7 +243,7 @@ jobs:
         run: |
           printenv > .envs
            docker run --env-file .envs \
-           -e PROJECTS="${{ inputs.ecr_repository }}" \
+           -e PROJECTS="${{ steps.env2.outputs.PROJECTS }}" \
            -e IMAGE_TAG=${{ steps.env1.outputs.IMAGE_TAG }} \
            -e ENVIRONMENTS="${{ inputs.production_environments }}" \
            -e ECR_REPOSITORY="${{ inputs.ecr_repository }}" \
@@ -227,7 +254,7 @@ jobs:
         run: |
           printenv > .envs
            docker run --env-file .envs \
-           -e PROJECTS="${{ inputs.ecr_repository }}" \
+           -e PROJECTS="${{ steps.env2.outputs.PROJECTS }}" \
            -e IMAGE_TAG=${{ steps.env1.outputs.IMAGE_TAG }} \
            -e ENVIRONMENTS="development" \
            -e ECR_REPOSITORY="${{ inputs.ecr_repository }}" \
@@ -240,7 +267,7 @@ jobs:
           output=
           status="failure"
           url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          
+
           if [ "${{ steps.build-test.outcome }}" != "true" ]; then 
             output="${output}Building the Test image has failed!"
           fi

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -170,6 +170,7 @@ jobs:
           echo "DEFAULT_BRANCH_FOR_CACHING=$DEFAULT_BRANCH_FOR_CACHING" >> $GITHUB_OUTPUT
           USE_BUILDX="false"
           if [ "${{ inputs.platforms }}" != "" ]; then
+            echo "hello?"
             USE_BUILDX="true"
           fi
           echo "USE_BUILDX=$USE_BUILDX" >> $GITHUB_OUTPUT

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -180,20 +180,28 @@ jobs:
         run: |
           docker pull ${{ steps.env2.outputs.IMAGE_ID }}:cache || echo "true"
           BUILD_TEST_COMMAND=""
+          COMMON="--target development --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.IMAGE_ID }}:cache "
 
           if [ "${{ inputs.platforms }}" != "" ]; then
-            BUILD_TEST_COMMAND="docker buildx build --platform=${{ inputs.platforms }} --target development --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.IMAGE_ID }}:cache -t app:cache ."
+            BUILD_TEST_COMMAND="docker buildx build --platform=${{ inputs.platforms }} $COMMON -t app:cache ."
           else
-            BUILD_TEST_COMMAND="DOCKER_BUILDKIT=1 docker build --target development --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.IMAGE_ID }}:cache -t ${{ steps.env2.outputs.IMAGE_ID }}:cache -t app:cache ."
+            BUILD_TEST_COMMAND="DOCKER_BUILDKIT=1 docker build $COMMON -t ${{ steps.env2.outputs.IMAGE_ID }}:cache -t app:cache ."
           fi
 
-          BUILDX_PUSH_TEST_COMMAND="docker buildx build --platform=${{ inputs.platforms }} --target development --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.IMAGE_ID }}:cache -t ${{ steps.env2.outputs.IMAGE_ID }}:cache ."
+          BUILDX_PUSH_TEST_COMMAND="docker buildx build --push --platform=${{ inputs.platforms }} $COMMON -t ${{ steps.env2.outputs.IMAGE_ID }}:cache ."
           echo "BUILDX_PUSH_TEST_COMMAND=$BUILDX_PUSH_TEST_COMMAND" >> $GITHUB_OUTPUT
 
+          ## Note this is only needed as buildx doesnt support --load with multiple platforms yet but is on roadmap
+          ## if it is ever supported simply remove this and the "Load test oci image step" and add --load to the first BUILD_TEST_COMMAND
+          BUILDX_LOAD_TEST_COMMAND="docker buildx build --load $COMMON -t app:cache ."
+          echo "BUILDX_LOAD_TEST_COMMAND=$BUILDX_LOAD_TEST_COMMAND" >> $GITHUB_OUTPUT
+
           $($BUILD_TEST_COMMAND)
-          if [ "${{ inputs.platforms }}" != "" ]; then
-            docker buildx build --load --target development --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.IMAGE_ID }}:cache -t app:cache .
-          fi
+
+      - name: Load Test OCI Image
+        if: inputs.platforms != ''
+        id: load-test
+        run: $(${{ steps.build-test.outputs.BUILDX_LOAD_TEST_COMMAND }})
 
       - name: Task ${{ inputs.extra_task_1_name }}
         if: inputs.extra_task_1 != ''
@@ -217,13 +225,14 @@ jobs:
         id: build-production
         run: |
           BUILD_PRODUCTION_COMMAND=""
+          COMMON="--target production --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg RELEASE_VERSION=${{ steps.env1.outputs.IMAGE_TAG }} --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.IMAGE_ID }}:cache -t ${{ steps.env2.outputs.IMAGE_ID }}:${{ steps.env1.outputs.IMAGE_TAG }} ."
           if [ "${{ inputs.platforms }}" != "" ]; then
-            BUILD_PRODUCTION_COMMAND="docker buildx build --platform=${{ inputs.platforms }} --target production --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg RELEASE_VERSION=${{ steps.env1.outputs.IMAGE_TAG }} --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.IMAGE_ID }}:cache -t ${{ steps.env2.outputs.IMAGE_ID }}:${{ steps.env1.outputs.IMAGE_TAG }} ."
+            BUILD_PRODUCTION_COMMAND="docker buildx build --platform=${{ inputs.platforms }} $COMMON"
           else
-            BUILD_PRODUCTION_COMMAND="DOCKER_BUILDKIT=1 docker build --target production --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg RELEASE_VERSION=${{ steps.env1.outputs.IMAGE_TAG }} --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.IMAGE_ID }}:cache -t ${{ steps.env2.outputs.IMAGE_ID }}:${{ steps.env1.outputs.IMAGE_TAG }} ."
+            BUILD_PRODUCTION_COMMAND="DOCKER_BUILDKIT=1 docker build $COMMON"
           fi
 
-          BUILDX_PUSH_PRODUCTION_COMMAND="docker buildx build --push --platform=${{ inputs.platforms }} --target production --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg RELEASE_VERSION=${{ steps.env1.outputs.IMAGE_TAG }} --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.IMAGE_ID }}:cache -t ${{ steps.env2.outputs.IMAGE_ID }}:${{ steps.env1.outputs.IMAGE_TAG }} ."
+          BUILDX_PUSH_PRODUCTION_COMMAND="docker buildx build --push --platform=${{ inputs.platforms }} $COMMON"
           echo "BUILDX_PUSH_PRODUCTION_COMMAND=$BUILDX_PUSH_PRODUCTION_COMMAND" >> $GITHUB_OUTPUT
 
           $($BUILD_PRODUCTION_COMMAND)

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -203,7 +203,7 @@ jobs:
           BUILDX_LOAD_TEST_COMMAND="docker buildx build --load $COMMON -t app:cache ."
           echo "BUILDX_LOAD_TEST_COMMAND=$BUILDX_LOAD_TEST_COMMAND" >> $GITHUB_OUTPUT
 
-          $($BUILD_TEST_COMMAND)
+          $BUILD_TEST_COMMAND
 
       - name: Load Test OCI Image
         if: ${{ steps.env2.outputs.USE_BUILDX }} == 'true'
@@ -242,7 +242,7 @@ jobs:
           BUILDX_PUSH_PRODUCTION_COMMAND="docker buildx build --push --platform=${{ inputs.platforms }} $COMMON"
           echo "BUILDX_PUSH_PRODUCTION_COMMAND=$BUILDX_PUSH_PRODUCTION_COMMAND" >> $GITHUB_OUTPUT
 
-          $($BUILD_PRODUCTION_COMMAND)
+          $BUILD_PRODUCTION_COMMAND
 
       - name: Task ${{ inputs.production_build_task_1_name }}
         if: inputs.production_build_task_1 != ''

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -151,10 +151,8 @@ jobs:
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: |
-          DOCKER_ECR=${{ secrets.DOCKER_ECR }}
-          echo "DOCKER_ECR=$DOCKER_ECR" >> $GITHUB_ENV
           VERSION=$(${{ inputs.version_command }})
-          BASE_IMAGE="${DOCKER_ECR}ruby-base:${VERSION}"
+          BASE_IMAGE="${{ secrets.DOCKER_ECR }}ruby-base:${VERSION}"
           echo "BASE_IMAGE=$BASE_IMAGE" >> $GITHUB_OUTPUT
           # Strip git ref prefix from version
           IMAGE_ID=$(echo "$ECR_REGISTRY/${{ inputs.ecr_repository }}" | tr '[A-Z]' '[a-z]')

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -192,7 +192,7 @@ jobs:
             BUILD_TEST_COMMAND="docker buildx build --platform=${{ inputs.platforms }} $COMMON -t ${{ steps.env2.outputs.IMAGE_ID }}:cache -t app:cache ."
           else
             docker pull ${{ steps.env2.outputs.IMAGE_ID }}:cache || echo "true"
-            BUILD_TEST_COMMAND="DOCKER_BUILDKIT=1 docker build $COMMON -t ${{ steps.env2.outputs.IMAGE_ID }}:cache -t app:cache ."
+            BUILD_TEST_COMMAND="docker build $COMMON -t ${{ steps.env2.outputs.IMAGE_ID }}:cache -t app:cache ."
           fi
 
           BUILDX_PUSH_TEST_COMMAND="docker buildx build --push --platform=${{ inputs.platforms }} $COMMON -t ${{ steps.env2.outputs.IMAGE_ID }}:cache ."
@@ -203,7 +203,7 @@ jobs:
           BUILDX_LOAD_TEST_COMMAND="docker buildx build --load $COMMON -t app:cache ."
           echo "BUILDX_LOAD_TEST_COMMAND=$BUILDX_LOAD_TEST_COMMAND" >> $GITHUB_OUTPUT
 
-          $BUILD_TEST_COMMAND
+          DOCKER_BUILDKIT=1 $BUILD_TEST_COMMAND
 
       - name: Load Test OCI Image
         if: ${{ steps.env2.outputs.USE_BUILDX }} == 'true'
@@ -236,13 +236,13 @@ jobs:
           if [ "${{ steps.env2.outputs.USE_BUILDX }}" == "true" ]; then
             BUILD_PRODUCTION_COMMAND="docker buildx build --platform=${{ inputs.platforms }} $COMMON"
           else
-            BUILD_PRODUCTION_COMMAND="DOCKER_BUILDKIT=1 docker build $COMMON"
+            BUILD_PRODUCTION_COMMAND="docker build $COMMON"
           fi
 
           BUILDX_PUSH_PRODUCTION_COMMAND="docker buildx build --push --platform=${{ inputs.platforms }} $COMMON"
           echo "BUILDX_PUSH_PRODUCTION_COMMAND=$BUILDX_PUSH_PRODUCTION_COMMAND" >> $GITHUB_OUTPUT
 
-          $BUILD_PRODUCTION_COMMAND
+          DOCKER_BUILDKIT=1 $BUILD_PRODUCTION_COMMAND
 
       - name: Task ${{ inputs.production_build_task_1_name }}
         if: inputs.production_build_task_1 != ''

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -232,14 +232,14 @@ jobs:
         id: build-production
         run: |
           BUILD_PRODUCTION_COMMAND=""
-          COMMON="--target production --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg RELEASE_VERSION=${{ steps.env1.outputs.IMAGE_TAG }} --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.IMAGE_ID }}:cache -t ${{ steps.env2.outputs.IMAGE_ID }}:${{ steps.env1.outputs.IMAGE_TAG }} ."
+          COMMON="--target production --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg RELEASE_VERSION=${{ steps.env1.outputs.IMAGE_TAG }} --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.IMAGE_ID }}:cache -t ${{ steps.env2.outputs.IMAGE_ID }}:${{ steps.env1.outputs.IMAGE_TAG }}"
           if [ "${{ steps.env2.outputs.USE_BUILDX }}" == "true" ]; then
-            BUILD_PRODUCTION_COMMAND="docker buildx build --platform=${{ inputs.platforms }} $COMMON"
+            BUILD_PRODUCTION_COMMAND="docker buildx build --platform=${{ inputs.platforms }} $COMMON ."
           else
-            BUILD_PRODUCTION_COMMAND="docker build $COMMON"
+            BUILD_PRODUCTION_COMMAND="docker build $COMMON ."
           fi
 
-          BUILDX_PUSH_PRODUCTION_COMMAND="docker buildx build --push --platform=${{ inputs.platforms }} $COMMON"
+          BUILDX_PUSH_PRODUCTION_COMMAND="docker buildx build --push --platform=${{ inputs.platforms }} $COMMON ."
           echo "BUILDX_PUSH_PRODUCTION_COMMAND=$BUILDX_PUSH_PRODUCTION_COMMAND" >> $GITHUB_OUTPUT
 
           ## Note this is only needed as buildx doesnt support --load with multiple platforms yet but is on roadmap

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -172,7 +172,7 @@ jobs:
           if [ "${{ inputs.platforms }}" != "" ]; then
             USE_BUILDX="true"
           fi
-          echo "USE_BUILDX="$USE_BUILDX" >> $GITHUB_OUTPUT
+          echo "USE_BUILDX=$USE_BUILDX" >> $GITHUB_OUTPUT
 
       - name: Set up QEMU
         if: ${{ steps.env2.outputs.USE_BUILDX }} == 'true'

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -320,35 +320,35 @@ jobs:
           status="failure"
           url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
-          if [ "${{ steps.build-test.outcome }}" != "true" ]; then 
+          if [ "${{ steps.build-test.outcome }}" == "failure" ]; then 
             output="${output}Building the Test image has failed!"
           fi
 
-          if [ "${{ steps.extra-task-1.outcome }}" != "true" ]; then 
+          if [ "${{ steps.extra-task-1.outcome }}" == "failure" ]; then 
             output="${output}${{ inputs.extra_task_1_name }} failed!"
           fi
 
-          if [ "${{ steps.extra-task-2.outcome }}" != "true" ]; then 
+          if [ "${{ steps.extra-task-2.outcome }}" == "failure" ]; then 
             output="${output}${{ inputs.extra_task_2_name }} failed!"
           fi
 
-          if [ "${{ steps.extra-task-3.outcome }}" != "true" ]; then 
+          if [ "${{ steps.extra-task-3.outcome }}" == "failure" ]; then 
             output="${output}${{ inputs.extra_task_3_name }} failed!"
           fi
 
-          if [ "${{ steps.build-test.outcome }}" != "true" ]; then 
+          if [ "${{ steps.build-production.outcome }}" == "failure" ]; then 
             output="${output}Building the Production image has failed!"
           fi
 
-          if [ "${{ steps.production-extra-task-1.outcome }}" != "true" ]; then 
+          if [ "${{ steps.production-extra-task-1.outcome }}" == "failure" ]; then 
             output="${output}${{ inputs.production_extra_task_1_name }} failed!"
           fi
 
-          if [ "${{ steps.production-extra-task-2.outcome }}" != "true" ]; then 
+          if [ "${{ steps.production-extra-task-2.outcome }}" == "failure" ]; then 
             output="${output}${{ inputs.production_extra_task_2_name }} failed!"
           fi
 
-          if [ "${{ steps.production-extra-task-3.outcome }}" != "true" ]; then 
+          if [ "${{ steps.production-extra-task-3.outcome }}" == "failure" ]; then 
             output="${output}${{ inputs.production_extra_task_3_name }} failed!"
           fi
 


### PR DESCRIPTION
* adds logic to make branch for caching default to default branch if unset
* makes dev_url optional for apps that dont have a url
* fixes up the error checks
* adds logic to support platforms, if platforms buildx is used for the given platforms, but requires additional steps due to --load not currently being supported on buildx when multiple platforms
* adds a projects param which if not set defaults to the ecr_repository (app_name) and if it is set just defines what apps need updating in terraform for the given image build