### PR TITLE
add logic to allow a step to update a specfifc environment when develop is still in use

### DIFF
--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -75,8 +75,14 @@ on:
       extra_task_3:
         default: ""
         type: string
+      development_environments:
+        default: "development"
+        type: string
+      test_environments:
+        default: ""
+        type: string
       production_environments:
-        required: true
+        default: "test,production"
         type: string
     secrets:
       DOCKER_ECR:
@@ -301,14 +307,25 @@ jobs:
            -e ECR_REPOSITORY="${{ inputs.ecr_repository }}" \
            ${{ steps.env2.outputs.ECR_REGISTRY }}/publish_app:latest
 
-      - name: Update GitOps Repo to trigger deploys for development
-        if: inputs.event_name == 'issue_comment' || (steps.env1.outputs.BRANCH_NAME == inputs.default_develop_branch &&  inputs.event_name == 'push')
+      - name: Update GitOps Repo to trigger deploys for test
+        if: inputs.test_environments != '' && inputs.default_develop_branch != '' && steps.env1.outputs.BRANCH_NAME == inputs.default_develop_branch &&  inputs.event_name == 'push'
         run: |
           printenv > .envs
            docker run --env-file .envs \
            -e PROJECTS="${{ steps.env2.outputs.PROJECTS }}" \
            -e IMAGE_TAG=${{ steps.env1.outputs.IMAGE_TAG }} \
-           -e ENVIRONMENTS="development" \
+           -e ENVIRONMENTS="${{ inputs.test_environments }}" \
+           -e ECR_REPOSITORY="${{ inputs.ecr_repository }}" \
+           ${{ steps.env2.outputs.ECR_REGISTRY }}/publish_app:latest
+
+      - name: Update GitOps Repo to trigger deploys for development
+        if: inputs.event_name == 'issue_comment'
+        run: |
+          printenv > .envs
+           docker run --env-file .envs \
+           -e PROJECTS="${{ steps.env2.outputs.PROJECTS }}" \
+           -e IMAGE_TAG=${{ steps.env1.outputs.IMAGE_TAG }} \
+           -e ENVIRONMENTS="${{ inputs.development_environments }}" \
            -e ECR_REPOSITORY="${{ inputs.ecr_repository }}" \
            ${{ steps.env2.outputs.ECR_REGISTRY }}/publish_app:latest
 


### PR DESCRIPTION
This is needed for apps that still rely on develop i.e rapididp,

so /deploy goes to develop
merges to develop will go to test
and merges to master will go to production