### PR TITLE
Upgrade `aws-actions/configure-aws-credentials` to v2

### DIFF
--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -153,7 +153,7 @@ jobs:
           path: .github/reusable_workflow
 
       - name: Configure AWS Credentials
-        uses: aws-actions/configure-aws-credentials@master
+        uses: aws-actions/configure-aws-credentials@v2
         with:
           aws-region: ap-southeast-2
           role-to-assume: ${{ secrets.ROLE }}


### PR DESCRIPTION
`master` is no longer the [main branch](https://github.com/aws-actions/configure-aws-credentials), there are also deprecation messages and the occasional failure now: 

<img width="899" alt="Screenshot 2023-07-04 at 9 04 38 am" src="https://github.com/ausaccessfed/workflows/assets/39336960/8795745a-2660-4228-834f-3488a6258703">
