### PR TITLE
Support generic containers

### DIFF
--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -296,9 +296,9 @@ jobs:
         id: build-production-result
         if: always()
         run: |
-          cat build.txt 2>/dev/null
-          cat build_error.txt 2>/dev/null
-          ([[ -f build_error.txt ]] || [[ ! -f build.txt ]]) && exit 1
+          cat build.txt 2>/dev/null || echo ""
+          cat build_error.txt 2>/dev/null || echo ""
+          ([[ -f build_error.txt -o ! -f build.txt ]]) && exit 1
 
       - name: ${{ inputs.extra_task_1_name }} Result
         id: extra-task-1
@@ -306,9 +306,9 @@ jobs:
         env:
           TASK_NUM: 1
         run: |
-          cat task_$TASK_NUM.txt 2>/dev/null
-          cat task_$TASK_NUM_error.txt 2>/dev/null
-          ([[ -f task_$TASK_NUM_error.txt ]] || [[ ! -f task_$TASK_NUM.txt ]]) && exit 1
+          cat task_$TASK_NUM.txt 2>/dev/null || echo ""
+          cat task_$TASK_NUM_error.txt 2>/dev/null || echo ""
+          ([[ -f task_$TASK_NUM_error.txt -o ! -f task_$TASK_NUM.txt ]]) && exit 1
 
       - name: ${{ inputs.extra_task_2_name }} Result
         id: extra-task-2
@@ -316,9 +316,9 @@ jobs:
         env:
           TASK_NUM: 2
         run: |
-          cat task_$TASK_NUM.txt 2>/dev/null
-          cat task_$TASK_NUM_error.txt 2>/dev/null
-          ([[ -f task_$TASK_NUM_error.txt ]] || [[ ! -f task_$TASK_NUM.txt ]]) && exit 1
+          cat task_$TASK_NUM.txt 2>/dev/null || echo ""
+          cat task_$TASK_NUM_error.txt 2>/dev/null || echo ""
+          ([[ -f task_$TASK_NUM_error.txt -o ! -f task_$TASK_NUM.txt ]]) && exit 1
 
       - name: ${{ inputs.extra_task_3_name }} Result
         id: extra-task-3
@@ -326,9 +326,9 @@ jobs:
         env:
           TASK_NUM: 3
         run: |
-          cat task_$TASK_NUM.txt 2>/dev/null
-          cat task_$TASK_NUM_error.txt 2>/dev/null
-          ([[ -f task_$TASK_NUM_error.txt ]] || [[ ! -f task_$TASK_NUM.txt ]]) && exit 1
+          cat task_$TASK_NUM.txt 2>/dev/null || echo ""
+          cat task_$TASK_NUM_error.txt 2>/dev/null || echo ""
+          ([[ -f task_$TASK_NUM_error.txt -o ! -f task_$TASK_NUM.txt ]]) && exit 1
 
       - name: ${{ inputs.extra_task_4_name }} Result
         id: extra-task-4
@@ -336,9 +336,9 @@ jobs:
         env:
           TASK_NUM: 4
         run: |
-          cat task_$TASK_NUM.txt 2>/dev/null
-          cat task_$TASK_NUM_error.txt 2>/dev/null
-          ([[ -f task_$TASK_NUM_error.txt ]] || [[ ! -f task_$TASK_NUM.txt ]]) && exit 1
+          cat task_$TASK_NUM.txt 2>/dev/null || echo ""
+          cat task_$TASK_NUM_error.txt 2>/dev/null || echo ""
+          ([[ -f task_$TASK_NUM_error.txt -o ! -f task_$TASK_NUM.txt ]]) && exit 1
 
       - name: ${{ inputs.extra_task_5_name }} Result
         id: extra-task-5
@@ -346,9 +346,9 @@ jobs:
         env:
           TASK_NUM: 5
         run: |
-          cat task_$TASK_NUM.txt 2>/dev/null
-          cat task_$TASK_NUM_error.txt 2>/dev/null
-          ([[ -f task_$TASK_NUM_error.txt ]] || [[ ! -f task_$TASK_NUM.txt ]]) && exit 1
+          cat task_$TASK_NUM.txt 2>/dev/null || echo ""
+          cat task_$TASK_NUM_error.txt 2>/dev/null || echo ""
+          ([[ -f task_$TASK_NUM_error.txt -o ! -f task_$TASK_NUM.txt ]]) && exit 1
 
       - name: ${{ inputs.extra_task_6_name }} Result
         id: extra-task-6
@@ -356,17 +356,17 @@ jobs:
         env:
           TASK_NUM: 6
         run: |
-          cat task_$TASK_NUM.txt 2>/dev/null
-          cat task_$TASK_NUM_error.txt 2>/dev/null
-          ([[ -f task_$TASK_NUM_error.txt ]] || [[ ! -f task_$TASK_NUM.txt ]]) && exit 1
+          cat task_$TASK_NUM.txt 2>/dev/null || echo ""
+          cat task_$TASK_NUM_error.txt 2>/dev/null || echo ""
+          ([[ -f task_$TASK_NUM_error.txt -o ! -f task_$TASK_NUM.txt ]]) && exit 1
 
       - name: Image lint results
         id: image-lint
         if: inputs.event_name != 'issue_comment' && always()
         run: |
-          cat image_lint.txt 2>/dev/null
-          cat image_lint_error.txt 2>/dev/null
-          ([[ -f image_lint_error.txt ]] || [[ ! -f image_lint.txt ]]) && exit 1
+          cat image_lint.txt 2>/dev/null || echo ""
+          cat image_lint_error.txt 2>/dev/null || echo ""
+          ([[ -f image_lint_error.txt -o ! -f image_lint.txt ]]) && exit 1
 
       - name: Run Image scan on production image for cves
         if: inputs.event_name != 'issue_comment'

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -6,6 +6,10 @@ on:
       image_tag:
         default: ""
         type: string
+      # currently only supresses image scans/lints, but can be expanded if needed
+      supress_task_failures:
+        default: true
+        type: boolean
       ecr_repository:
         required: true
         type: string
@@ -286,8 +290,7 @@ jobs:
           IMAGE_SCANNER_COMMON="docker run -u 0 -v /var/run/docker.sock:/var/run/docker.sock -v ${PWD}:/app/repo ${{ steps.env2.outputs.IMAGE_SCANNER_IMAGE_TAG }}"
           echo "IMAGE_SCANNER_COMMON=$IMAGE_SCANNER_COMMON" >> $GITHUB_OUTPUT
 
-          LINT_COMMAND="./scripts/lint ${{ steps.env2.outputs.LOCAL_IMAGE_TAG }} /app/repo/Dockerfile"
-          export EXTRA_TASK_IMAGE_LINT_COMMAND="$IMAGE_SCANNER_COMMON $LINT_COMMAND"
+          export EXTRA_TASK_IMAGE_LINT_COMMAND="$IMAGE_SCANNER_COMMON ./scripts/lint ${{ steps.env2.outputs.LOCAL_IMAGE_TAG }} /app/repo/Dockerfile ${{ inputs.supress_task_failures }}"
 
           ./.github/reusable_workflow/scripts/additional_tasks.sh
 
@@ -357,7 +360,8 @@ jobs:
             ${{ steps.env2.outputs.PRODUCTION_IMAGE_TAG }} \
             $image_sha \
             /app/repo/Dockerfile \
-            ${{ secrets.SNYK_TOKEN }}
+            ${{ secrets.SNYK_TOKEN }} \
+            ${{ inputs.supress_task_failures }}
 
       - name: Push to ECR
         run: |

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -2,7 +2,8 @@ name: Build Docker Image
 on:
   workflow_call:
     inputs:
-      hardcoded_image_tag:
+      # If not provided then assumes auto generated stable-SHA256
+      image_tag:
         default: ""
         type: string
       ecr_repository:
@@ -135,8 +136,8 @@ jobs:
           fi
           echo "BRANCH_NAME=$branch_name" >> $GITHUB_OUTPUT
 
-          if [ "${{ inputs.hardcoded_image_tag }}" != "" ]; then
-            image_tag="${{ inputs.hardcoded_image_tag }}"
+          if [ "${{ inputs.image_tag }}" != "" ]; then
+            image_tag="${{ inputs.image_tag }}"
           elif [ "${{ inputs.event_name }}" == "issue_comment" ]; then
             image_tag=adhoc-${{steps.comment-branch.outputs.head_ref}}-${{steps.comment-branch.outputs.head_sha}}
           else

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -167,8 +167,7 @@ jobs:
         with:
           repository: ausaccessfed/workflows
           token: ${{ secrets.GITHUB_TOKEN }}
-          # TODO: change back to main
-          ref: feature/support-generic-containers
+          ref: main
           path: .github/reusable_workflow
 
       - name: Configure AWS Credentials

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -296,56 +296,56 @@ jobs:
         id: build-production-result
         if: always()
         run: |
-          cat build.txt
+          cat build.txt || echo ""
           [[ -f build_error.txt ]] && cat build_error.txt && exit 1 || echo ""
 
       - name: ${{ inputs.extra_task_1_name }} Result
         id: extra-task-1
         if: inputs.event_name != 'issue_comment' && inputs.extra_task_1 != '' && always()
         run: |
-          cat task_1.txt 
+          cat task_1.txt || echo ""
           [[ -f task_1_error.txt ]] && cat task_1_error.txt && exit 1 ||  echo ""
 
       - name: ${{ inputs.extra_task_2_name }} Result
         id: extra-task-2
         if: inputs.event_name != 'issue_comment' && inputs.extra_task_2 != '' && always()
         run: |
-          cat task_2.txt 
+          cat task_2.txt || echo ""
           [[ -f task_2_error.txt ]] && cat task_2_error.txt && exit 1 ||  echo ""
 
       - name: ${{ inputs.extra_task_3_name }} Result
         id: extra-task-3
         if: inputs.event_name != 'issue_comment' && inputs.extra_task_3 != '' && always()
         run: |
-          cat task_3.txt 
+          cat task_3.txt || echo "" 
           [[ -f task_3_error.txt ]] && cat task_3_error.txt && exit 1 ||  echo ""
 
       - name: ${{ inputs.extra_task_4_name }} Result
         id: extra-task-4
         if: inputs.event_name != 'issue_comment' && inputs.extra_task_4 != '' && always()
         run: |
-          cat task_4.txt 
+          cat task_4.txt || echo "" 
           [[ -f task_4_error.txt ]] && cat task_4_error.txt && exit 1 ||  echo ""
 
       - name: ${{ inputs.extra_task_5_name }} Result
         id: extra-task-5
         if: inputs.event_name != 'issue_comment' && inputs.extra_task_5 != '' && always()
         run: |
-          cat task_5.txt 
+          cat task_5.txt  || echo ""
           [[ -f task_5_error.txt ]] && cat task_5_error.txt && exit 1 ||  echo ""
 
       - name: ${{ inputs.extra_task_6_name }} Result
         id: extra-task-6
         if: inputs.event_name != 'issue_comment' && inputs.extra_task_6 != '' && always()
         run: |
-          cat task_6.txt 
+          cat task_6.txt || echo ""
           [[ -f task_6_error.txt ]] && cat task_6_error.txt && exit 1 ||  echo ""
 
       - name: Image lint results
         id: image-lint
         if: inputs.event_name != 'issue_comment' && always()
         run: |
-          cat image_lint.txt 
+          cat image_lint.txt || echo ""
           [[ -f image_lint_error.txt ]] && cat image_lint_error.txt && exit 1 ||  echo ""
 
       - name: Run Image scan on production image for cves

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -145,9 +145,22 @@ jobs:
           fi
           echo "BRANCH_NAME=$branch_name" >> $GITHUB_OUTPUT
 
+          is_slash_deploy=$([ "${{ inputs.event_name }}" == "issue-comment" ] && echo "true" || echo "false")
+          echo "IS_SLASH_DEPLOY=$is_slash_deploy" >> $GITHUB_OUTPUT
+
+          is_default_branch_push=$(([ "${{ inputs.event_name }}" == "push" ] && [ "$branch_name" == "${{ inputs.default_branch }}" ]) && echo "true" || echo "false")
+          echo "IS_DEFAULT_BRANCH_PUSH=$is_default_branch_push" >> $GITHUB_OUTPUT
+
+          is_default_development_branch_push=$(([ "${{ inputs.event_name }}" == "push" ] && [ "$branch_name" == "${{ inputs.default_develop_branch }}" ]) && echo "true" || echo "false")
+          echo "IS_DEFAULT_DEVELOPMENT_BRANCH_PUSH=$is_default_development_branch_push" >> $GITHUB_OUTPUT
+
+          default_branch_for_caching=$([ "$default_branch_for_caching" == "" ] && echo "${{ inputs.default_branch }}" || echo "${{ inputs.default_branch_for_caching }}")
+          is_default_cache_branch_push=$(([ "${{ inputs.event_name }}" == "push" ] && [ "$branch_name" == "$default_branch_for_caching" ]) && echo "true" || echo "false")
+          echo "IS_DEFAULT_CACHE_BRANCH_PUSH=$is_default_cache_branch_push" >> $GITHUB_OUTPUT
+
           if [ "${{ inputs.override_image_tag }}" != "" ]; then
             image_tag="${{ inputs.override_image_tag }}"
-          elif [ "${{ inputs.event_name }}" == "issue_comment" ]; then
+          elif [ "$IS_SLASH_DEPLOY" == "true" ]; then
             image_tag=adhoc-${{steps.comment-branch.outputs.head_ref}}-${{steps.comment-branch.outputs.head_sha}}
           else
             image_tag=stable-${{ github.sha }}
@@ -208,12 +221,6 @@ jobs:
             PROJECTS="${{ inputs.projects }}"
           fi
           echo "PROJECTS=$PROJECTS" >> $GITHUB_OUTPUT
-
-          DEFAULT_BRANCH_FOR_CACHING="${{ inputs.default_branch_for_caching }}"
-          if [ "$DEFAULT_BRANCH_FOR_CACHING" == "" ]; then
-            DEFAULT_BRANCH_FOR_CACHING="${{ inputs.default_branch }}"
-          fi
-          echo "DEFAULT_BRANCH_FOR_CACHING=$DEFAULT_BRANCH_FOR_CACHING" >> $GITHUB_OUTPUT
 
           USE_BUILDX="false"
           if [ "${{ inputs.platforms }}" != "" ]; then
@@ -280,7 +287,7 @@ jobs:
 
           export EXTRA_TASK_INC=10
           # Make sure EXTRA_TASK_INC inc is greater than the amount of EXTRA_TASKS
-          if [ "${{inputs.event_name}}" != "issue_comment" ]; then
+          if [ "${{steps.env1.outputs.IS_SLASH_DEPLOY}}" == "false" ]; then
             export EXTRA_TASK_1='${{ inputs.extra_task_1 }}'
             export EXTRA_TASK_2='${{ inputs.extra_task_2 }}'
             export EXTRA_TASK_3='${{ inputs.extra_task_3 }}'
@@ -309,72 +316,72 @@ jobs:
 
       - name: ${{ inputs.extra_task_1_name }} Result
         id: extra-task-1
-        if: inputs.event_name != 'issue_comment' && inputs.extra_task_1 != '' && always()
+        if: steps.env1.outputs.IS_SLASH_DEPLOY == 'false' && inputs.extra_task_1 != '' && always()
         env:
           NUMBER: 1
         run: cat task_${NUMBER}.txt || (cat task_${NUMBER}_error.txt && exit 1)
 
       - name: ${{ inputs.extra_task_2_name }} Result
         id: extra-task-2
-        if: inputs.event_name != 'issue_comment' && inputs.extra_task_2 != '' && always()
+        if: steps.env1.outputs.IS_SLASH_DEPLOY == 'false' && inputs.extra_task_2 != '' && always()
         env:
           NUMBER: 2
         run: cat task_${NUMBER}.txt || (cat task_${NUMBER}_error.txt && exit 1)
 
       - name: ${{ inputs.extra_task_3_name }} Result
         id: extra-task-3
-        if: inputs.event_name != 'issue_comment' && inputs.extra_task_3 != '' && always()
+        if: steps.env1.outputs.IS_SLASH_DEPLOY == 'false' && inputs.extra_task_3 != '' && always()
         env:
           NUMBER: 3
         run: cat task_${NUMBER}.txt || (cat task_${NUMBER}_error.txt && exit 1)
 
       - name: ${{ inputs.extra_task_4_name }} Result
         id: extra-task-4
-        if: inputs.event_name != 'issue_comment' && inputs.extra_task_4 != '' && always()
+        if: steps.env1.outputs.IS_SLASH_DEPLOY == 'false' && inputs.extra_task_4 != '' && always()
         env:
           NUMBER: 4
         run: cat task_${NUMBER}.txt || (cat task_${NUMBER}_error.txt && exit 1)
 
       - name: ${{ inputs.extra_task_5_name }} Result
         id: extra-task-5
-        if: inputs.event_name != 'issue_comment' && inputs.extra_task_5 != '' && always()
+        if: steps.env1.outputs.IS_SLASH_DEPLOY == 'false' && inputs.extra_task_5 != '' && always()
         env:
           NUMBER: 5
         run: cat task_${NUMBER}.txt || (cat task_${NUMBER}_error.txt && exit 1)
 
       - name: ${{ inputs.extra_task_6_name }} Result
         id: extra-task-6
-        if: inputs.event_name != 'issue_comment' && inputs.extra_task_6 != '' && always()
+        if: steps.env1.outputs.IS_SLASH_DEPLOY == 'false' && inputs.extra_task_6 != '' && always()
         env:
           NUMBER: 6
         run: cat task_${NUMBER}.txt || (cat task_${NUMBER}_error.txt && exit 1)
 
       - name: Image lint results
         id: image-lint
-        if: inputs.event_name != 'issue_comment' && always()
+        if: steps.env1.outputs.IS_SLASH_DEPLOY == 'false' && always()
         run: cat image_lint.txt || (cat image_lint_error.txt && exit 1)
 
-      # TODO: comment out for now, can we move to a more async job approuch?
-      # - name: Run Image scan on production image for cves
-      #   if: inputs.event_name != 'issue_comment'
-      #   run: |
-      #     image_sha="$(docker images --no-trunc --quiet ${{ steps.env2.outputs.PRODUCTION_IMAGE_ID_TAG }})"
-      #     ${{ steps.build-production.outputs.IMAGE_SCANNER_COMMON }} \
-      #       ./scripts/scan \
-      #       ${{ steps.env2.outputs.PRODUCTION_IMAGE_ID_TAG }} \
-      #       $image_sha \
-      #       /app/Dockerfile \
-      #       ${{ secrets.SNYK_TOKEN }} \
-      #       ${{ inputs.supress_task_failures }}
+      # TODO: masster/main branch merges only for now
+      - name: Run Image scan on production image for cves
+        if: steps.env1.outputs.IS_DEFAULT_BRANCH_PUSH == 'true'
+        run: |
+          image_sha="$(docker images --no-trunc --quiet ${{ steps.env2.outputs.PRODUCTION_IMAGE_ID_TAG }})"
+          ${{ steps.build-production.outputs.IMAGE_SCANNER_COMMON }} \
+            ./scripts/scan \
+            ${{ steps.env2.outputs.PRODUCTION_IMAGE_ID_TAG }} \
+            $image_sha \
+            /app/Dockerfile \
+            ${{ secrets.SNYK_TOKEN }} \
+            ${{ inputs.supress_task_failures }}
 
       - name: Push to ECR
         run: |
           if [ \
-              "${{inputs.event_name}}" == "push" -a "${{steps.env1.outputs.BRANCH_NAME}}" == "${{inputs.default_branch}}" \
+              "${{steps.env1.outputs.IS_DEFAULT_BRANCH_PUSH}}" == "true" \
               -o \
-              "${{inputs.event_name}}" == "issue_comment" \
+              "${{steps.env1.outputs.IS_SLASH_DEPLOY}}" == "true" \
               -o \
-              "${{steps.env1.outputs.BRANCH_NAME}}" == "${{inputs.default_develop_branch}}" -a "${{inputs.event_name}}" == "push" \
+              "${{steps.env1.outputs.IS_DEFAULT_DEVELOPMENT_BRANCH_PUSH}}" == "true" \
             ]; then
             if [ "${{ steps.env2.outputs.USE_BUILDX }}" == "true" ]; then
               export PRODUCTION_PUSH_COMMAND="${{ steps.build-production.outputs.BUILDX_PUSH_PRODUCTION_COMMAND }}"
@@ -383,7 +390,7 @@ jobs:
             fi
           fi
 
-          if [ "${{inputs.event_name}}" == "push" ] && [ "${{steps.env1.outputs.BRANCH_NAME}}" == "${{steps.env2.outputs.DEFAULT_BRANCH_FOR_CACHING}}" ]; then
+          if [ "${{steps.env1.outputs.IS_DEFAULT_CACHE_BRANCH_PUSH}}" == "true" ]; then
             if [ "${{ steps.env2.outputs.USE_BUILDX }}" == "true" ]; then
               export CACHE_PUSH_COMMAND="${{ steps.build-test.outputs.BUILDX_PUSH_TEST_COMMAND }}"
             else
@@ -393,27 +400,22 @@ jobs:
           ./.github/reusable_workflow/scripts/push_images.sh
 
           if [ \
-              "${{inputs.event_name}}" == "push" -a "${{steps.env1.outputs.BRANCH_NAME}}" == "${{inputs.default_branch}}" \
+              "${{steps.env1.outputs.IS_DEFAULT_BRANCH_PUSH}}" == "true" \
               -o \
-              "${{inputs.event_name}}" == "issue_comment" \
+              "${{steps.env1.outputs.IS_SLASH_DEPLOY}}" == "true" \
               -o \
-              "${{steps.env1.outputs.BRANCH_NAME}}" == "${{inputs.default_develop_branch}}" -a "${{inputs.event_name}}" == "push" \
+              "${{steps.env1.outputs.IS_DEFAULT_DEVELOPMENT_BRANCH_PUSH}}" == "true" \
             ]; then
-              cat push_production.txt
-              [[ -f push_production_error.txt ]] && cat push_production_error.txt && exit 1 || echo ""
+              cat push_production.txt || (cat push_production_error.txt && exit 1)
           fi
-          if [ "${{inputs.event_name}}" == "push" ] && [ "${{steps.env1.outputs.BRANCH_NAME}}" == "${{steps.env2.outputs.DEFAULT_BRANCH_FOR_CACHING}}" ]; then
-            cat push_cache.txt 
-            [[ -f push_cache_error.txt ]] && cat push_cache_error.txt && exit 1 || echo ""
+          if [ "${{steps.env1.outputs.IS_DEFAULT_CACHE_BRANCH_PUSH}}" == "true" ]; then
+            cat push_cache.txt || (cat push_cache_error.txt && exit 1)
           fi
 
       ## no point making the gitops repo triggers async, they will fight each other
       ## and usually only 1 if statement is called anyway
       - name: Update GitOps Repo to trigger deploys
-        if: |
-          inputs.production_environments != '' && 
-          steps.env1.outputs.BRANCH_NAME == inputs.default_branch && 
-          inputs.event_name == 'push'
+        if: inputs.production_environments != '' && steps.env1.outputs.IS_DEFAULT_BRANCH_PUSH == 'true'
         run: |
           printenv > .envs
            docker run --env-file .envs \
@@ -424,10 +426,7 @@ jobs:
            ${{ steps.env2.outputs.PUBLISH_APP_IMAGE_ID_TAG }}
 
       - name: Update GitOps Repo to trigger deploys for test
-        if: |
-          inputs.test_environments != '' && 
-          steps.env1.outputs.BRANCH_NAME == inputs.default_develop_branch && 
-          inputs.event_name == 'push'
+        if: inputs.test_environments != '' && steps.env1.outputs.IS_DEFAULT_DEVELOPMENT_BRANCH_PUSH == 'true'
         run: |
           printenv > .envs
            docker run --env-file .envs \
@@ -438,9 +437,7 @@ jobs:
            ${{ steps.env2.outputs.PUBLISH_APP_IMAGE_ID_TAG }}
 
       - name: Update GitOps Repo to trigger deploys for development
-        if: |
-          inputs.development_environments != '' &&
-          inputs.event_name == 'issue_comment'
+        if: inputs.development_environments != '' && steps.env1.outputs.IS_SLASH_DEPLOY == 'true'
         run: |
           printenv > .envs
            docker run --env-file .envs \
@@ -452,7 +449,7 @@ jobs:
 
       - name: check for failures
         id: failure-check
-        if: inputs.event_name == 'issue_comment' && always()
+        if: steps.env1.outputs.IS_SLASH_DEPLOY == 'true' && always()
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -485,7 +482,7 @@ jobs:
           fi
 
       - name: Set final commit status
-        if: inputs.event_name == 'issue_comment' && always()
+        if: steps.env1.outputs.IS_SLASH_DEPLOY == 'true' && always()
         uses: myrotvorets/set-commit-status-action@38f3f27c7d52fb381273e95542f07f0fba301307 # v2.0.0
         with:
           sha: ${{ steps.comment-branch.outputs.head_sha }}

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -2,10 +2,6 @@ name: Build Docker Image
 on:
   workflow_call:
     inputs:
-      # If not provided then assumes auto generated stable-SHA256
-      override_image_tag:
-        default: ""
-        type: string
       ecr_repository:
         required: true
         type: string
@@ -154,10 +150,7 @@ jobs:
           is_default_cache_branch_push=$(([ "${{ inputs.event_name }}" == "push" ] && [ "$branch_name" == "$default_branch_for_caching" ]) && echo "true" || echo "false")
           echo "IS_DEFAULT_CACHE_BRANCH_PUSH=$is_default_cache_branch_push" >> $GITHUB_OUTPUT
 
-
-          if [ "${{ inputs.override_image_tag }}" != "" ]; then
-            image_tag="${{ inputs.override_image_tag }}"
-          elif [ "$IS_SLASH_DEPLOY" == "true" ]; then
+          if [ "$IS_SLASH_DEPLOY" == "true" ]; then
             image_tag=adhoc-${{steps.comment-branch.outputs.head_ref}}-${{steps.comment-branch.outputs.head_sha}}
           else
             image_tag=stable-${{ github.sha }}
@@ -208,6 +201,8 @@ jobs:
           echo "IMAGE_ID=$IMAGE_ID" >> $GITHUB_OUTPUT
 
           echo "PRODUCTION_IMAGE_ID_TAG=$IMAGE_ID:${{ steps.env1.outputs.IMAGE_TAG }}" >> $GITHUB_OUTPUT
+
+          echo "LATEST_IMAGE_ID_TAG=$IMAGE_ID:latest" >> $GITHUB_OUTPUT
 
           echo "CACHE_IMAGE_ID_TAG=$IMAGE_ID:cache" >> $GITHUB_OUTPUT
 
@@ -271,7 +266,7 @@ jobs:
         id: build-production
         run: |
           BUILD_PRODUCTION_COMMAND=""
-          COMMON="--target production --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg RELEASE_VERSION=${{ steps.env1.outputs.IMAGE_TAG }} --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.CACHE_IMAGE_ID_TAG }} -t ${{ steps.env2.outputs.PRODUCTION_IMAGE_ID_TAG }}"
+          COMMON="--target production --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg RELEASE_VERSION=${{ steps.env1.outputs.IMAGE_TAG }} --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.CACHE_IMAGE_ID_TAG }} -t ${{ steps.env2.outputs.PRODUCTION_IMAGE_ID_TAG }} -t ${{ steps.env2.outputs.LATEST_IMAGE_ID_TAG }}"
           if [ "${{ steps.env2.outputs.USE_BUILDX }}" == "true" ]; then
             BUILD_PRODUCTION_COMMAND="docker buildx build --platform=${{ inputs.platforms }} $COMMON ."
           else
@@ -400,7 +395,7 @@ jobs:
             if [ "${{ steps.env2.outputs.USE_BUILDX }}" == "true" ]; then
               export PRODUCTION_PUSH_COMMAND="${{ steps.build-production.outputs.BUILDX_PUSH_PRODUCTION_COMMAND }}"
             else 
-              export PRODUCTION_PUSH_COMMAND="docker push ${{ steps.env2.outputs.PRODUCTION_IMAGE_ID_TAG }}"
+              export PRODUCTION_PUSH_COMMAND="docker push ${{ steps.env2.outputs.PRODUCTION_IMAGE_ID_TAG }} && docker push ${{ steps.env2.outputs.LATEST_IMAGE_ID_TAG }}"
             fi
           fi
 

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -296,8 +296,19 @@ jobs:
             export EXTRA_TASK_6='${{ inputs.extra_task_6 }}'
           fi
 
+          IMAGE_SCANNER_EXTRAS=""
+          if [ -f "${PWD}/Dockerfile" ]; then
+            IMAGE_SCANNER_EXTRAS="-v ${PWD}/Dockerfile:/app/Dockerfile ${IMAGE_SCANNER_EXTRAS}"
+          fi
+          if [ -f "${PWD}/.dockleignore" ]; then
+            IMAGE_SCANNER_EXTRAS="-v ${PWD}/.dockleignore:/app/.dockleignore ${IMAGE_SCANNER_EXTRAS}"
+          fi
+          if [ -f "${PWD}/.hadolint.yaml" ]; then
+            IMAGE_SCANNER_EXTRAS="-v ${PWD}/.hadolint.yaml:/app/.hadolint.yaml ${IMAGE_SCANNER_EXTRAS}"
+          fi
+
           # must run as root to access the docker socket
-          IMAGE_SCANNER_COMMON="docker run -u 0 -v /var/run/docker.sock:/var/run/docker.sock -v ${PWD}/Dockerfile:/app/Dockerfile ${{ steps.env2.outputs.IMAGE_SCANNER_IMAGE_ID_TAG }}"
+          IMAGE_SCANNER_COMMON="docker run -u 0 -v /var/run/docker.sock:/var/run/docker.sock ${IMAGE_SCANNER_EXTRAS} ${{ steps.env2.outputs.IMAGE_SCANNER_IMAGE_ID_TAG }}"
           echo "IMAGE_SCANNER_COMMON=$IMAGE_SCANNER_COMMON" >> $GITHUB_OUTPUT
 
           export EXTRA_TASK_IMAGE_LINT_COMMAND="$IMAGE_SCANNER_COMMON ./scripts/lint ${{ steps.env2.outputs.LOCAL_CACHE_IMAGE_ID_TAG }} /app/Dockerfile ${{ inputs.supress_task_failures }}"
@@ -361,7 +372,7 @@ jobs:
         if: steps.env1.outputs.IS_SLASH_DEPLOY == 'false' && always()
         run: cat image_lint.txt || (cat image_lint_error.txt && exit 1)
 
-      # TODO: masster/main branch merges only for now
+      # TODO: master/main branch merges only for now
       - name: Run Image scan on production image for cves
         if: steps.env1.outputs.IS_DEFAULT_BRANCH_PUSH == 'true'
         run: |

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -349,7 +349,7 @@ jobs:
         if: inputs.event_name != 'issue_comment'
         run: |
           SCAN_COMMAND="./scripts/scan '${{ steps.env1.outputs.IMAGE_TAG }}' '$(shell docker images --no-trunc --quiet ${{ steps.env1.outputs.IMAGE_TAG }})' '/app/repo/Dockerfile' '${{ secrets.SNYK_TOKEN }}'"
-          $(shell ${{ steps.build-production.outputs.IMAGE_SCANNER_COMMON }} $SCAN_COMMAND)
+          $("${{ steps.build-production.outputs.IMAGE_SCANNER_COMMON }} $SCAN_COMMAND")
 
       - name: Push to ECR
         run: |

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -296,8 +296,7 @@ jobs:
         id: build-production-result
         if: always()
         run: |
-          cat build.txt 
-          [[ -f build_error.txt ]] && cat build_error.txt && exit 1 ||  echo ""
+          cat build.txt || (cat build_error.txt && exit 1)
 
       - name: ${{ inputs.extra_task_1_name }} Result
         id: extra-task-1
@@ -357,8 +356,7 @@ jobs:
         id: image-lint
         if: inputs.event_name != 'issue_comment' && always()
         run: |
-          cat image_lint.txt 
-          [[ -f image_lint_error.txt ]] && cat image_lint_error.txt && exit 1 ||  echo ""
+          cat image_lint.txt || (cat image_lint_error.txt && exit 1)
 
       - name: Run Image scan on production image for cves
         if: inputs.event_name != 'issue_comment'

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -96,6 +96,8 @@ on:
         required: true
       ROLE:
         required: true
+      SNYK_TOKEN:
+        required: true
 jobs:
   run:
     runs-on: ${{ inputs.runner }}
@@ -175,6 +177,8 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: |
           echo "ECR_REGISTRY=$ECR_REGISTRY" >> $GITHUB_OUTPUT
+          echo "PUBLISH_APP_IMAGE_TAG=$ECR_REGISTRY/publish_app:latest" >> $GITHUB_OUTPUT
+          echo "IMAGE_SCANNER_IMAGE_TAG=$ECR_REGISTRY/image-scanner:latest" >> $GITHUB_OUTPUT
 
           VERSION=$(${{ inputs.version_command }})
           BASE_IMAGE="${{ secrets.DOCKER_ECR }}ruby-base:${VERSION}"
@@ -183,6 +187,11 @@ jobs:
           # Strip git ref prefix from version
           IMAGE_ID=$(echo "$ECR_REGISTRY/${{ inputs.ecr_repository }}" | tr '[A-Z]' '[a-z]')
           echo "IMAGE_ID=$IMAGE_ID" >> $GITHUB_OUTPUT
+
+          echo "CACHE_IMAGE_TAG=$IMAGE_ID:cache" >> $GITHUB_OUTPUT
+
+          # This is just a image tag without ecr to avoid ever grabbing from ecr
+          echo "LOCAL_IMAGE_TAG=app:cache" >> $GITHUB_OUTPUT
 
           PROJECTS="${{ inputs.ecr_repository }}"
           if [ "${{ inputs.projects }}" != "" ]; then
@@ -214,21 +223,21 @@ jobs:
         id: build-test
         run: |
           BUILD_TEST_COMMAND=""
-          COMMON="--target development --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.IMAGE_ID }}:cache "
+          COMMON="--target development --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.CACHE_IMAGE_TAG }} "
 
           if [ "${{ steps.env2.outputs.USE_BUILDX }}" == "true" ]; then
-            BUILD_TEST_COMMAND="docker buildx build --platform=${{ inputs.platforms }} $COMMON -t ${{ steps.env2.outputs.IMAGE_ID }}:cache -t app:cache ."
+            BUILD_TEST_COMMAND="docker buildx build --platform=${{ inputs.platforms }} $COMMON -t ${{ steps.env2.outputs.CACHE_IMAGE_TAG }} -t ${{ steps.env2.outputs.LOCAL_IMAGE_TAG }} ."
           else
-            docker pull ${{ steps.env2.outputs.IMAGE_ID }}:cache || echo "true"
-            BUILD_TEST_COMMAND="docker build $COMMON -t ${{ steps.env2.outputs.IMAGE_ID }}:cache -t app:cache ."
+            docker pull ${{ steps.env2.outputs.CACHE_IMAGE_TAG }} || echo "true"
+            BUILD_TEST_COMMAND="docker build $COMMON -t ${{ steps.env2.outputs.CACHE_IMAGE_TAG }} -t ${{ steps.env2.outputs.LOCAL_IMAGE_TAG }} ."
           fi
 
-          BUILDX_PUSH_TEST_COMMAND="docker buildx build --push --platform=${{ inputs.platforms }} $COMMON -t ${{ steps.env2.outputs.IMAGE_ID }}:cache ."
+          BUILDX_PUSH_TEST_COMMAND="docker buildx build --push --platform=${{ inputs.platforms }} $COMMON -t ${{ steps.env2.outputs.CACHE_IMAGE_TAG }} ."
           echo "BUILDX_PUSH_TEST_COMMAND=$BUILDX_PUSH_TEST_COMMAND" >> $GITHUB_OUTPUT
 
           ## Note this is only needed as buildx doesnt support --load with multiple platforms yet but is on roadmap
           ## if it is ever supported simply remove this and the "Load test oci image step" and add --load to the first BUILD_TEST_COMMAND
-          BUILDX_LOAD_TEST_COMMAND="docker buildx build --load $COMMON -t app:cache ."
+          BUILDX_LOAD_TEST_COMMAND="docker buildx build --load $COMMON -t ${{ steps.env2.outputs.LOCAL_IMAGE_TAG }} ."
           echo "BUILDX_LOAD_TEST_COMMAND=$BUILDX_LOAD_TEST_COMMAND" >> $GITHUB_OUTPUT
 
           DOCKER_BUILDKIT=1 $BUILD_TEST_COMMAND
@@ -242,7 +251,7 @@ jobs:
         id: build-production
         run: |
           BUILD_PRODUCTION_COMMAND=""
-          COMMON="--target production --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg RELEASE_VERSION=${{ steps.env1.outputs.IMAGE_TAG }} --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.IMAGE_ID }}:cache -t ${{ steps.env2.outputs.IMAGE_ID }}:${{ steps.env1.outputs.IMAGE_TAG }}"
+          COMMON="--target production --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg RELEASE_VERSION=${{ steps.env1.outputs.IMAGE_TAG }} --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.CACHE_IMAGE_TAG }} -t ${{ steps.env2.outputs.IMAGE_ID }}:${{ steps.env1.outputs.IMAGE_TAG }}"
           if [ "${{ steps.env2.outputs.USE_BUILDX }}" == "true" ]; then
             BUILD_PRODUCTION_COMMAND="docker buildx build --platform=${{ inputs.platforms }} $COMMON ."
           else
@@ -258,6 +267,7 @@ jobs:
           echo "BUILDX_LOAD_PRODUCTION_COMMAND=$BUILDX_LOAD_PRODUCTION_COMMAND" >> $GITHUB_OUTPUT
 
           export BUILD_PRODUCTION_COMMAND="$BUILD_PRODUCTION_COMMAND"
+
           export EXTRA_TASK_INC=10
           # Make sure EXTRA_TASK_INC inc is greater than the amount of EXTRA_TASKS
           if [ "${{inputs.event_name}}" != "issue_comment" ]; then
@@ -268,6 +278,13 @@ jobs:
             export EXTRA_TASK_5='${{ inputs.extra_task_5 }}'
             export EXTRA_TASK_6='${{ inputs.extra_task_6 }}'
           fi
+
+          IMAGE_SCANNER_COMMON="docker run -v /var/run/docker.sock:/var/run/docker.sock -v ${PWD}:/app/repo ${{ steps.env2.outputs.IMAGE_SCANNER_IMAGE_TAG }}"
+          echo "IMAGE_SCANNER_COMMON=$IMAGE_SCANNER_COMMON" >> $GITHUB_OUTPUT
+
+          LINT_COMMAND="./scripts/lint ${{ steps.env2.outputs.LOCAL_IMAGE_TAG }} /app/repo/Dockerfile"
+          export EXTRA_TASK_IMAGE_LINT_COMMAND="$IMAGE_SCANNER_COMMON $LINT_COMMAND"
+
           ./.github/reusable_workflow/scripts/additional_tasks.sh
 
       - name: Load Production OCI Image
@@ -324,6 +341,19 @@ jobs:
           cat task_6.txt 
           [[ -f task_6_error.txt ]] && cat task_6_error.txt && exit 1 ||  echo ""
 
+      - name: Image lint results
+        id: image-lint
+        if: inputs.event_name != 'issue_comment' && always()
+        run: |
+          cat image_lint.txt 
+          [[ -f image_lint_error.txt ]] && cat image_lint_error.txt && exit 1 ||  echo ""
+
+      - name: Run Image scan on production image for cves
+        if: inputs.event_name != 'issue_comment'
+        run: |
+          SCAN_COMMAND="./scripts/scan '${{ steps.env1.outputs.IMAGE_TAG }}' '$(shell docker images --no-trunc --quiet ${{ steps.env1.outputs.IMAGE_TAG }})' '/app/repo/Dockerfile' '${{ secrets.SNYK_TOKEN }}'"
+          $(shell ${{ steps.build-production.outputs.IMAGE_SCANNER_COMMON }} $SCAN_COMMAND)
+
       - name: Push to ECR
         run: |
           if [ \
@@ -344,7 +374,7 @@ jobs:
             if [ "${{ steps.env2.outputs.USE_BUILDX }}" == "true" ]; then
               export CACHE_PUSH_COMMAND="${{ steps.build-test.outputs.BUILDX_PUSH_TEST_COMMAND }}"
             else
-              export CACHE_PUSH_COMMAND="docker push ${{ steps.env2.outputs.IMAGE_ID }}:cache"
+              export CACHE_PUSH_COMMAND="docker push ${{ steps.env2.outputs.CACHE_IMAGE_TAG }}"
             fi
           fi
           ./.github/reusable_workflow/scripts/push_images.sh
@@ -378,7 +408,7 @@ jobs:
            -e IMAGE_TAG=${{ steps.env1.outputs.IMAGE_TAG }} \
            -e ENVIRONMENTS="${{ inputs.production_environments }}" \
            -e ECR_REPOSITORY="${{ inputs.ecr_repository }}" \
-           ${{ steps.env2.outputs.ECR_REGISTRY }}/publish_app:latest
+           ${{ steps.env2.outputs.PUBLISH_APP_IMAGE_TAG }}
 
       - name: Update GitOps Repo to trigger deploys for test
         if: |
@@ -392,7 +422,7 @@ jobs:
            -e IMAGE_TAG=${{ steps.env1.outputs.IMAGE_TAG }} \
            -e ENVIRONMENTS="${{ inputs.test_environments }}" \
            -e ECR_REPOSITORY="${{ inputs.ecr_repository }}" \
-           ${{ steps.env2.outputs.ECR_REGISTRY }}/publish_app:latest
+           ${{ steps.env2.outputs.PUBLISH_APP_IMAGE_TAG }}
 
       - name: Update GitOps Repo to trigger deploys for development
         if: |
@@ -405,7 +435,7 @@ jobs:
            -e IMAGE_TAG=${{ steps.env1.outputs.IMAGE_TAG }} \
            -e ENVIRONMENTS="${{ inputs.development_environments }}" \
            -e ECR_REPOSITORY="${{ inputs.ecr_repository }}" \
-           ${{ steps.env2.outputs.ECR_REGISTRY }}/publish_app:latest
+           ${{ steps.env2.outputs.PUBLISH_APP_IMAGE_TAG }}
 
       - name: check for failures
         id: failure-check

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -298,7 +298,7 @@ jobs:
         run: |
           cat build.txt 2>/dev/null || echo ""
           cat build_error.txt 2>/dev/null || echo ""
-          ([[ -f build_error.txt ]] || [[ ! -f build.txt ]]) && exit 1
+          [[ ! -f build_error.txt ]] || [[ -f build.txt ]]
 
       - name: ${{ inputs.extra_task_1_name }} Result
         id: extra-task-1
@@ -308,7 +308,7 @@ jobs:
         run: |
           cat task_$TASK_NUM.txt 2>/dev/null || echo ""
           cat task_$TASK_NUM_error.txt 2>/dev/null || echo ""
-          ([[ -f task_$TASK_NUM_error.txt ]] || [[ ! -f task_$TASK_NUM.txt ]]) && exit 1
+          [[ ! -f task_$TASK_NUM_error.txt ]] || [[ -f task_$TASK_NUM.txt ]]
 
       - name: ${{ inputs.extra_task_2_name }} Result
         id: extra-task-2
@@ -318,7 +318,7 @@ jobs:
         run: |
           cat task_$TASK_NUM.txt 2>/dev/null || echo ""
           cat task_$TASK_NUM_error.txt 2>/dev/null || echo ""
-          ([[ -f task_$TASK_NUM_error.txt ]] || [[ ! -f task_$TASK_NUM.txt ]]) && exit 1
+          [[ ! -f task_$TASK_NUM_error.txt ]] || [[ -f task_$TASK_NUM.txt ]]
 
       - name: ${{ inputs.extra_task_3_name }} Result
         id: extra-task-3
@@ -328,7 +328,7 @@ jobs:
         run: |
           cat task_$TASK_NUM.txt 2>/dev/null || echo ""
           cat task_$TASK_NUM_error.txt 2>/dev/null || echo ""
-          ([[ -f task_$TASK_NUM_error.txt ]] || [[ ! -f task_$TASK_NUM.txt ]]) && exit 1
+          [[ ! -f task_$TASK_NUM_error.txt ]] || [[ -f task_$TASK_NUM.txt ]]
 
       - name: ${{ inputs.extra_task_4_name }} Result
         id: extra-task-4
@@ -338,7 +338,7 @@ jobs:
         run: |
           cat task_$TASK_NUM.txt 2>/dev/null || echo ""
           cat task_$TASK_NUM_error.txt 2>/dev/null || echo ""
-          ([[ -f task_$TASK_NUM_error.txt ]] || [[ ! -f task_$TASK_NUM.txt ]]) && exit 1
+          [[ ! -f task_$TASK_NUM_error.txt ]] || [[ -f task_$TASK_NUM.txt ]]
 
       - name: ${{ inputs.extra_task_5_name }} Result
         id: extra-task-5
@@ -348,7 +348,7 @@ jobs:
         run: |
           cat task_$TASK_NUM.txt 2>/dev/null || echo ""
           cat task_$TASK_NUM_error.txt 2>/dev/null || echo ""
-          ([[ -f task_$TASK_NUM_error.txt ]] || [[ ! -f task_$TASK_NUM.txt ]]) && exit 1
+          [[ ! -f task_$TASK_NUM_error.txt ]] || [[ -f task_$TASK_NUM.txt ]]
 
       - name: ${{ inputs.extra_task_6_name }} Result
         id: extra-task-6
@@ -358,7 +358,7 @@ jobs:
         run: |
           cat task_$TASK_NUM.txt 2>/dev/null || echo ""
           cat task_$TASK_NUM_error.txt 2>/dev/null || echo ""
-          ([[ -f task_$TASK_NUM_error.txt ]] || [[ ! -f task_$TASK_NUM.txt ]]) && exit 1
+          [[ ! -f task_$TASK_NUM_error.txt ]] || [[ -f task_$TASK_NUM.txt ]]
 
       - name: Image lint results
         id: image-lint
@@ -366,7 +366,7 @@ jobs:
         run: |
           cat image_lint.txt 2>/dev/null || echo ""
           cat image_lint_error.txt 2>/dev/null || echo ""
-          ([[ -f image_lint_error.txt ]] || [[ ! -f image_lint.txt ]]) && exit 1
+          [[ ! -f image_lint_error.txt ]] || [[ -f image_lint.txt ]]
 
       - name: Run Image scan on production image for cves
         if: inputs.event_name != 'issue_comment'

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -298,7 +298,7 @@ jobs:
         run: |
           cat build.txt 2>/dev/null || echo ""
           cat build_error.txt 2>/dev/null || echo ""
-          [[ ! -f build_error.txt ]] || [[ -f build.txt ]]
+          (([[ -f build_error.txt ]] || [[ ! -f build.txt ]]) && exit 1) || echo ""
 
       - name: ${{ inputs.extra_task_1_name }} Result
         id: extra-task-1
@@ -306,9 +306,11 @@ jobs:
         env:
           TASK_NUM: 1
         run: |
+          # cat task_$TASK_NUM.txt 
+          # [[ -f task_$TASK_NUM_error.txt ]] && cat task_$TASK_NUM_error.txt && exit 1 || echo ""
           cat task_$TASK_NUM.txt 2>/dev/null || echo ""
           cat task_$TASK_NUM_error.txt 2>/dev/null || echo ""
-          [[ ! -f task_$TASK_NUM_error.txt ]] || [[ -f task_$TASK_NUM.txt ]]
+          (([[ ! -f task_$TASK_NUM_error.txt ]] || [[ -f task_$TASK_NUM.txt ]]) && exit 1) || echo ""
 
       - name: ${{ inputs.extra_task_2_name }} Result
         id: extra-task-2
@@ -318,7 +320,7 @@ jobs:
         run: |
           cat task_$TASK_NUM.txt 2>/dev/null || echo ""
           cat task_$TASK_NUM_error.txt 2>/dev/null || echo ""
-          [[ ! -f task_$TASK_NUM_error.txt ]] || [[ -f task_$TASK_NUM.txt ]]
+          (([[ ! -f task_$TASK_NUM_error.txt ]] || [[ -f task_$TASK_NUM.txt ]]) && exit 1) || echo ""
 
       - name: ${{ inputs.extra_task_3_name }} Result
         id: extra-task-3
@@ -328,7 +330,7 @@ jobs:
         run: |
           cat task_$TASK_NUM.txt 2>/dev/null || echo ""
           cat task_$TASK_NUM_error.txt 2>/dev/null || echo ""
-          [[ ! -f task_$TASK_NUM_error.txt ]] || [[ -f task_$TASK_NUM.txt ]]
+          (([[ ! -f task_$TASK_NUM_error.txt ]] || [[ -f task_$TASK_NUM.txt ]]) && exit 1) || echo ""
 
       - name: ${{ inputs.extra_task_4_name }} Result
         id: extra-task-4
@@ -338,7 +340,7 @@ jobs:
         run: |
           cat task_$TASK_NUM.txt 2>/dev/null || echo ""
           cat task_$TASK_NUM_error.txt 2>/dev/null || echo ""
-          [[ ! -f task_$TASK_NUM_error.txt ]] || [[ -f task_$TASK_NUM.txt ]]
+          (([[ ! -f task_$TASK_NUM_error.txt ]] || [[ -f task_$TASK_NUM.txt ]]) && exit 1) || echo ""
 
       - name: ${{ inputs.extra_task_5_name }} Result
         id: extra-task-5
@@ -348,7 +350,7 @@ jobs:
         run: |
           cat task_$TASK_NUM.txt 2>/dev/null || echo ""
           cat task_$TASK_NUM_error.txt 2>/dev/null || echo ""
-          [[ ! -f task_$TASK_NUM_error.txt ]] || [[ -f task_$TASK_NUM.txt ]]
+          (([[ ! -f task_$TASK_NUM_error.txt ]] || [[ -f task_$TASK_NUM.txt ]]) && exit 1) || echo ""
 
       - name: ${{ inputs.extra_task_6_name }} Result
         id: extra-task-6
@@ -358,7 +360,7 @@ jobs:
         run: |
           cat task_$TASK_NUM.txt 2>/dev/null || echo ""
           cat task_$TASK_NUM_error.txt 2>/dev/null || echo ""
-          [[ ! -f task_$TASK_NUM_error.txt ]] || [[ -f task_$TASK_NUM.txt ]]
+          (([[ ! -f task_$TASK_NUM_error.txt ]] || [[ -f task_$TASK_NUM.txt ]]) && exit 1) || echo ""
 
       - name: Image lint results
         id: image-lint
@@ -366,7 +368,7 @@ jobs:
         run: |
           cat image_lint.txt 2>/dev/null || echo ""
           cat image_lint_error.txt 2>/dev/null || echo ""
-          [[ ! -f image_lint_error.txt ]] || [[ -f image_lint.txt ]]
+          (([[ ! -f image_lint_error.txt ]] || [[ -f image_lint.txt ]]) && exit 1) || echo ""
 
       - name: Run Image scan on production image for cves
         if: inputs.event_name != 'issue_comment'

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -348,8 +348,12 @@ jobs:
       - name: Run Image scan on production image for cves
         if: inputs.event_name != 'issue_comment'
         run: |
-          SCAN_COMMAND="./scripts/scan '${{ steps.env1.outputs.IMAGE_TAG }}' '$(docker images --no-trunc --quiet ${{ steps.env1.outputs.IMAGE_TAG }})' '/app/repo/Dockerfile' '${{ secrets.SNYK_TOKEN }}'"
-          $("${{ steps.build-production.outputs.IMAGE_SCANNER_COMMON }} $SCAN_COMMAND")
+          image_sha="$(docker images --no-trunc --quiet ${{ steps.env1.outputs.IMAGE_TAG }})"
+          ${{ steps.build-production.outputs.IMAGE_SCANNER_COMMON }} \
+            ./scripts/scan \
+            '${{ steps.env1.outputs.IMAGE_TAG }}' \
+            '${image_sha}' \
+            '/app/repo/Dockerfile' '${{ secrets.SNYK_TOKEN }}'
 
       - name: Push to ECR
         run: |

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -354,9 +354,10 @@ jobs:
           image_sha="$(docker images --no-trunc --quiet ${{ steps.env2.outputs.PRODUCTION_IMAGE_TAG }})"
           ${{ steps.build-production.outputs.IMAGE_SCANNER_COMMON }} \
             ./scripts/scan \
-            '${{ steps.env2.outputs.PRODUCTION_IMAGE_TAG }}' \
-            '${image_sha}' \
-            '/app/repo/Dockerfile' '${{ secrets.SNYK_TOKEN }}'
+            ${{ steps.env2.outputs.PRODUCTION_IMAGE_TAG }} \
+            $image_sha \
+            /app/repo/Dockerfile \
+            ${{ secrets.SNYK_TOKEN }}
 
       - name: Push to ECR
         run: |

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -349,22 +349,22 @@ jobs:
           NUMBER: 6
         run: cat task_${NUMBER}.txt || (cat task_${NUMBER}_error.txt && exit 1)
 
-      - name: Image lint results
-        id: image-lint
-        if: inputs.event_name != 'issue_comment' && always()
-        run: cat image_lint.txt || (cat image_lint_error.txt && exit 1)
+      # - name: Image lint results
+      #   id: image-lint
+      #   if: inputs.event_name != 'issue_comment' && always()
+      #   run: cat image_lint.txt || (cat image_lint_error.txt && exit 1)
 
-      - name: Run Image scan on production image for cves
-        if: inputs.event_name != 'issue_comment'
-        run: |
-          image_sha="$(docker images --no-trunc --quiet ${{ steps.env2.outputs.PRODUCTION_IMAGE_TAG }})"
-          ${{ steps.build-production.outputs.IMAGE_SCANNER_COMMON }} \
-            ./scripts/scan \
-            ${{ steps.env2.outputs.PRODUCTION_IMAGE_TAG }} \
-            $image_sha \
-            /app/Dockerfile \
-            ${{ secrets.SNYK_TOKEN }} \
-            ${{ inputs.supress_task_failures }}
+      # - name: Run Image scan on production image for cves
+      #   if: inputs.event_name != 'issue_comment'
+      #   run: |
+      #     image_sha="$(docker images --no-trunc --quiet ${{ steps.env2.outputs.PRODUCTION_IMAGE_TAG }})"
+      #     ${{ steps.build-production.outputs.IMAGE_SCANNER_COMMON }} \
+      #       ./scripts/scan \
+      #       ${{ steps.env2.outputs.PRODUCTION_IMAGE_TAG }} \
+      #       $image_sha \
+      #       /app/Dockerfile \
+      #       ${{ secrets.SNYK_TOKEN }} \
+      #       ${{ inputs.supress_task_failures }}
 
       - name: Push to ECR
         run: |

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -189,6 +189,8 @@ jobs:
           IMAGE_ID=$(echo "$ECR_REGISTRY/${{ inputs.ecr_repository }}" | tr '[A-Z]' '[a-z]')
           echo "IMAGE_ID=$IMAGE_ID" >> $GITHUB_OUTPUT
 
+          echo "PRODUCTION_IMAGE_TAG=$IMAGE_ID:${{ steps.env1.outputs.IMAGE_TAG }}" >> $GITHUB_OUTPUT
+
           echo "CACHE_IMAGE_TAG=$IMAGE_ID:cache" >> $GITHUB_OUTPUT
 
           # This is just a image tag without ecr to avoid ever grabbing from ecr
@@ -252,7 +254,7 @@ jobs:
         id: build-production
         run: |
           BUILD_PRODUCTION_COMMAND=""
-          COMMON="--target production --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg RELEASE_VERSION=${{ steps.env1.outputs.IMAGE_TAG }} --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.CACHE_IMAGE_TAG }} -t ${{ steps.env2.outputs.IMAGE_ID }}:${{ steps.env1.outputs.IMAGE_TAG }}"
+          COMMON="--target production --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg RELEASE_VERSION=${{ steps.env1.outputs.IMAGE_TAG }} --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.CACHE_IMAGE_TAG }} -t ${{ steps.env2.outputs.PRODUCTION_IMAGE_TAG }}"
           if [ "${{ steps.env2.outputs.USE_BUILDX }}" == "true" ]; then
             BUILD_PRODUCTION_COMMAND="docker buildx build --platform=${{ inputs.platforms }} $COMMON ."
           else
@@ -349,10 +351,10 @@ jobs:
       - name: Run Image scan on production image for cves
         if: inputs.event_name != 'issue_comment'
         run: |
-          image_sha="$(docker images --no-trunc --quiet ${{ steps.env1.outputs.IMAGE_TAG }})"
+          image_sha="$(docker images --no-trunc --quiet ${{ steps.env2.outputs.PRODUCTION_IMAGE_TAG }})"
           ${{ steps.build-production.outputs.IMAGE_SCANNER_COMMON }} \
             ./scripts/scan \
-            '${{ steps.env1.outputs.IMAGE_TAG }}' \
+            '${{ steps.env2.outputs.PRODUCTION_IMAGE_TAG }}' \
             '${image_sha}' \
             '/app/repo/Dockerfile' '${{ secrets.SNYK_TOKEN }}'
 
@@ -368,7 +370,7 @@ jobs:
             if [ "${{ steps.env2.outputs.USE_BUILDX }}" == "true" ]; then
               export PRODUCTION_PUSH_COMMAND="${{ steps.build-production.outputs.BUILDX_PUSH_PRODUCTION_COMMAND }}"
             else 
-              export PRODUCTION_PUSH_COMMAND="docker push ${{ steps.env2.outputs.IMAGE_ID }}:${{ steps.env1.outputs.IMAGE_TAG }}"
+              export PRODUCTION_PUSH_COMMAND="docker push ${{ steps.env2.outputs.PRODUCTION_IMAGE_TAG }}"
             fi
           fi
 

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -6,10 +6,6 @@ on:
       override_image_tag:
         default: ""
         type: string
-      # currently only supresses image scans/lints, but can be expanded if needed
-      supress_task_failures:
-        default: true
-        type: boolean
       ecr_repository:
         required: true
         type: string
@@ -318,7 +314,7 @@ jobs:
           IMAGE_SCANNER_COMMON="docker run -u 0 -v /var/run/docker.sock:/var/run/docker.sock ${IMAGE_SCANNER_EXTRAS} ${{ steps.env2.outputs.IMAGE_SCANNER_IMAGE_ID_TAG }}"
           echo "IMAGE_SCANNER_COMMON=$IMAGE_SCANNER_COMMON" >> $GITHUB_OUTPUT
 
-          export EXTRA_TASK_IMAGE_LINT_COMMAND="$IMAGE_SCANNER_COMMON ./scripts/lint ${{ steps.env2.outputs.LOCAL_CACHE_IMAGE_ID_TAG }} /app/Dockerfile ${{ inputs.supress_task_failures }}"
+          export EXTRA_TASK_IMAGE_LINT_COMMAND="$IMAGE_SCANNER_COMMON ./scripts/lint ${{ steps.env2.outputs.LOCAL_CACHE_IMAGE_ID_TAG }} /app/Dockerfile"
 
           ./.github/reusable_workflow/scripts/additional_tasks.sh
 
@@ -390,8 +386,8 @@ jobs:
             $image_sha \
             /app/Dockerfile \
             ${{ secrets.SNYK_TOKEN }} \
-            ${{ inputs.supress_task_failures }}
-
+            true
+      # TODO: change the true above when were ready to enforce
       - name: Push to ECR
         run: |
           if [ \

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -157,7 +157,8 @@ jobs:
         with:
           repository: ausaccessfed/workflows
           token: ${{ secrets.GITHUB_TOKEN }}
-          ref: main
+          # TODO: change back to main
+          ref: feature/support-generic-containers
           path: .github/reusable_workflow
 
       - name: Configure AWS Credentials

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -290,10 +290,10 @@ jobs:
           fi
 
           # must run as root to access the docker socket
-          IMAGE_SCANNER_COMMON="docker run -u 0 -v /var/run/docker.sock:/var/run/docker.sock -v ${PWD}:/app/repo ${{ steps.env2.outputs.IMAGE_SCANNER_IMAGE_TAG }}"
+          IMAGE_SCANNER_COMMON="docker run -u 0 -v /var/run/docker.sock:/var/run/docker.sock -v ${PWD}/Dockerfile:/app/Dockerfile ${{ steps.env2.outputs.IMAGE_SCANNER_IMAGE_TAG }}"
           echo "IMAGE_SCANNER_COMMON=$IMAGE_SCANNER_COMMON" >> $GITHUB_OUTPUT
 
-          export EXTRA_TASK_IMAGE_LINT_COMMAND="$IMAGE_SCANNER_COMMON ./scripts/lint ${{ steps.env2.outputs.LOCAL_IMAGE_TAG }} /app/repo/Dockerfile ${{ inputs.supress_task_failures }}"
+          export EXTRA_TASK_IMAGE_LINT_COMMAND="$IMAGE_SCANNER_COMMON ./scripts/lint ${{ steps.env2.outputs.LOCAL_IMAGE_TAG }} /app/Dockerfile ${{ inputs.supress_task_failures }}"
 
           ./.github/reusable_workflow/scripts/additional_tasks.sh
 
@@ -362,7 +362,7 @@ jobs:
             ./scripts/scan \
             ${{ steps.env2.outputs.PRODUCTION_IMAGE_TAG }} \
             $image_sha \
-            /app/repo/Dockerfile \
+            /app/Dockerfile \
             ${{ secrets.SNYK_TOKEN }} \
             ${{ inputs.supress_task_failures }}
 

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -296,79 +296,70 @@ jobs:
         id: build-production-result
         if: always()
         run: |
-          cat build.txt 2>/dev/null || echo ""
-          cat build_error.txt 2>/dev/null || echo ""
-          (([[ -f build_error.txt ]] || [[ ! -f build.txt ]]) && exit 1) || echo ""
+          cat build.txt 2>/dev/null
+          cat build_error.txt 2>/dev/null
+          ([[ -f build_error.txt ]] || [[ ! -f build.txt ]]) && exit 1
 
       - name: ${{ inputs.extra_task_1_name }} Result
         id: extra-task-1
         if: inputs.event_name != 'issue_comment' && inputs.extra_task_1 != '' && always()
         env:
-          TASK_NUM: 1
+          NUMBER: 1
         run: |
-          # cat task_$TASK_NUM.txt 
-          # [[ -f task_$TASK_NUM_error.txt ]] && cat task_$TASK_NUM_error.txt && exit 1 || echo ""
-          cat task_$TASK_NUM.txt 2>/dev/null || echo ""
-          cat task_$TASK_NUM_error.txt 2>/dev/null || echo ""
-          (([[ ! -f task_$TASK_NUM_error.txt ]] || [[ -f task_$TASK_NUM.txt ]]) && exit 1) || echo ""
+          cat task_${NUMBER}.txt 
+          [[ -f task_${NUMBER}_error.txt ]] && cat task_${NUMBER}_error.txt && exit 1 ||  echo ""
 
       - name: ${{ inputs.extra_task_2_name }} Result
         id: extra-task-2
         if: inputs.event_name != 'issue_comment' && inputs.extra_task_2 != '' && always()
         env:
-          TASK_NUM: 2
+          NUMBER: 2
         run: |
-          cat task_$TASK_NUM.txt 2>/dev/null || echo ""
-          cat task_$TASK_NUM_error.txt 2>/dev/null || echo ""
-          (([[ ! -f task_$TASK_NUM_error.txt ]] || [[ -f task_$TASK_NUM.txt ]]) && exit 1) || echo ""
+          cat task_${NUMBER}.txt 
+          [[ -f task_${NUMBER}_error.txt ]] && cat task_${NUMBER}_error.txt && exit 1 ||  echo ""
 
       - name: ${{ inputs.extra_task_3_name }} Result
         id: extra-task-3
         if: inputs.event_name != 'issue_comment' && inputs.extra_task_3 != '' && always()
         env:
-          TASK_NUM: 3
+          NUMBER: 3
         run: |
-          cat task_$TASK_NUM.txt 2>/dev/null || echo ""
-          cat task_$TASK_NUM_error.txt 2>/dev/null || echo ""
-          (([[ ! -f task_$TASK_NUM_error.txt ]] || [[ -f task_$TASK_NUM.txt ]]) && exit 1) || echo ""
+          cat task_${NUMBER}.txt 
+          [[ -f task_${NUMBER}_error.txt ]] && cat task_${NUMBER}_error.txt && exit 1 ||  echo ""
 
       - name: ${{ inputs.extra_task_4_name }} Result
         id: extra-task-4
         if: inputs.event_name != 'issue_comment' && inputs.extra_task_4 != '' && always()
         env:
-          TASK_NUM: 4
+          NUMBER: 4
         run: |
-          cat task_$TASK_NUM.txt 2>/dev/null || echo ""
-          cat task_$TASK_NUM_error.txt 2>/dev/null || echo ""
-          (([[ ! -f task_$TASK_NUM_error.txt ]] || [[ -f task_$TASK_NUM.txt ]]) && exit 1) || echo ""
+          cat task_${NUMBER}.txt 
+          [[ -f task_${NUMBER}_error.txt ]] && cat task_${NUMBER}_error.txt && exit 1 ||  echo ""
 
       - name: ${{ inputs.extra_task_5_name }} Result
         id: extra-task-5
         if: inputs.event_name != 'issue_comment' && inputs.extra_task_5 != '' && always()
         env:
-          TASK_NUM: 5
+          NUMBER: 5
         run: |
-          cat task_$TASK_NUM.txt 2>/dev/null || echo ""
-          cat task_$TASK_NUM_error.txt 2>/dev/null || echo ""
-          (([[ ! -f task_$TASK_NUM_error.txt ]] || [[ -f task_$TASK_NUM.txt ]]) && exit 1) || echo ""
+          cat task_${NUMBER}.txt 
+          [[ -f task_${NUMBER}_error.txt ]] && cat task_${NUMBER}_error.txt && exit 1 ||  echo ""
 
       - name: ${{ inputs.extra_task_6_name }} Result
         id: extra-task-6
         if: inputs.event_name != 'issue_comment' && inputs.extra_task_6 != '' && always()
         env:
-          TASK_NUM: 6
+          NUMBER: 6
         run: |
-          cat task_$TASK_NUM.txt 2>/dev/null || echo ""
-          cat task_$TASK_NUM_error.txt 2>/dev/null || echo ""
-          (([[ ! -f task_$TASK_NUM_error.txt ]] || [[ -f task_$TASK_NUM.txt ]]) && exit 1) || echo ""
+          cat task_${NUMBER}.txt 
+          [[ -f task_${NUMBER}_error.txt ]] && cat task_${NUMBER}_error.txt && exit 1 ||  echo ""
 
       - name: Image lint results
         id: image-lint
         if: inputs.event_name != 'issue_comment' && always()
         run: |
-          cat image_lint.txt 2>/dev/null || echo ""
-          cat image_lint_error.txt 2>/dev/null || echo ""
-          (([[ ! -f image_lint_error.txt ]] || [[ -f image_lint.txt ]]) && exit 1) || echo ""
+          cat image_lint.txt 
+          [[ -f image_lint_error.txt ]] && cat image_lint_error.txt && exit 1 ||  echo ""
 
       - name: Run Image scan on production image for cves
         if: inputs.event_name != 'issue_comment'

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -298,7 +298,7 @@ jobs:
         run: |
           cat build.txt 2>/dev/null || echo ""
           cat build_error.txt 2>/dev/null || echo ""
-          ([ -f build_error.txt -o ! -f build.txt ]) && exit 1
+          ([[ -f build_error.txt ]] || [[ ! -f build.txt ]]) && exit 1
 
       - name: ${{ inputs.extra_task_1_name }} Result
         id: extra-task-1
@@ -308,7 +308,7 @@ jobs:
         run: |
           cat task_$TASK_NUM.txt 2>/dev/null || echo ""
           cat task_$TASK_NUM_error.txt 2>/dev/null || echo ""
-          ([ -f task_$TASK_NUM_error.txt -o ! -f task_$TASK_NUM.txt ]) && exit 1
+          ([[ -f task_$TASK_NUM_error.txt ]] || [[ ! -f task_$TASK_NUM.txt ]]) && exit 1
 
       - name: ${{ inputs.extra_task_2_name }} Result
         id: extra-task-2
@@ -318,7 +318,7 @@ jobs:
         run: |
           cat task_$TASK_NUM.txt 2>/dev/null || echo ""
           cat task_$TASK_NUM_error.txt 2>/dev/null || echo ""
-          ([ -f task_$TASK_NUM_error.txt -o ! -f task_$TASK_NUM.txt ]) && exit 1
+          ([[ -f task_$TASK_NUM_error.txt ]] || [[ ! -f task_$TASK_NUM.txt ]]) && exit 1
 
       - name: ${{ inputs.extra_task_3_name }} Result
         id: extra-task-3
@@ -328,7 +328,7 @@ jobs:
         run: |
           cat task_$TASK_NUM.txt 2>/dev/null || echo ""
           cat task_$TASK_NUM_error.txt 2>/dev/null || echo ""
-          ([ -f task_$TASK_NUM_error.txt -o ! -f task_$TASK_NUM.txt ]) && exit 1
+          ([[ -f task_$TASK_NUM_error.txt ]] || [[ ! -f task_$TASK_NUM.txt ]]) && exit 1
 
       - name: ${{ inputs.extra_task_4_name }} Result
         id: extra-task-4
@@ -338,7 +338,7 @@ jobs:
         run: |
           cat task_$TASK_NUM.txt 2>/dev/null || echo ""
           cat task_$TASK_NUM_error.txt 2>/dev/null || echo ""
-          ([ -f task_$TASK_NUM_error.txt -o ! -f task_$TASK_NUM.txt ]) && exit 1
+          ([[ -f task_$TASK_NUM_error.txt ]] || [[ ! -f task_$TASK_NUM.txt ]]) && exit 1
 
       - name: ${{ inputs.extra_task_5_name }} Result
         id: extra-task-5
@@ -348,7 +348,7 @@ jobs:
         run: |
           cat task_$TASK_NUM.txt 2>/dev/null || echo ""
           cat task_$TASK_NUM_error.txt 2>/dev/null || echo ""
-          ([ -f task_$TASK_NUM_error.txt -o ! -f task_$TASK_NUM.txt ]) && exit 1
+          ([[ -f task_$TASK_NUM_error.txt ]] || [[ ! -f task_$TASK_NUM.txt ]]) && exit 1
 
       - name: ${{ inputs.extra_task_6_name }} Result
         id: extra-task-6
@@ -358,7 +358,7 @@ jobs:
         run: |
           cat task_$TASK_NUM.txt 2>/dev/null || echo ""
           cat task_$TASK_NUM_error.txt 2>/dev/null || echo ""
-          ([ -f task_$TASK_NUM_error.txt -o ! -f task_$TASK_NUM.txt ]) && exit 1
+          ([[ -f task_$TASK_NUM_error.txt ]] || [[ ! -f task_$TASK_NUM.txt ]]) && exit 1
 
       - name: Image lint results
         id: image-lint
@@ -366,7 +366,7 @@ jobs:
         run: |
           cat image_lint.txt 2>/dev/null || echo ""
           cat image_lint_error.txt 2>/dev/null || echo ""
-          ([ -f image_lint_error.txt -o ! -f image_lint.txt ]) && exit 1
+          ([[ -f image_lint_error.txt ]] || [[ ! -f image_lint.txt ]]) && exit 1
 
       - name: Run Image scan on production image for cves
         if: inputs.event_name != 'issue_comment'

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -280,7 +280,8 @@ jobs:
             export EXTRA_TASK_6='${{ inputs.extra_task_6 }}'
           fi
 
-          IMAGE_SCANNER_COMMON="docker run -v /var/run/docker.sock:/var/run/docker.sock -v ${PWD}:/app/repo ${{ steps.env2.outputs.IMAGE_SCANNER_IMAGE_TAG }}"
+          # must run as root to access the docker socket
+          IMAGE_SCANNER_COMMON="docker run -u 0 -v /var/run/docker.sock:/var/run/docker.sock -v ${PWD}:/app/repo ${{ steps.env2.outputs.IMAGE_SCANNER_IMAGE_TAG }}"
           echo "IMAGE_SCANNER_COMMON=$IMAGE_SCANNER_COMMON" >> $GITHUB_OUTPUT
 
           LINT_COMMAND="./scripts/lint ${{ steps.env2.outputs.LOCAL_IMAGE_TAG }} /app/repo/Dockerfile"

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -201,7 +201,7 @@ jobs:
           echo "CACHE_IMAGE_TAG=$IMAGE_ID:cache" >> $GITHUB_OUTPUT
 
           # This is just a image tag without ecr to avoid ever grabbing from ecr
-          echo "LOCAL_IMAGE_TAG=app:cache" >> $GITHUB_OUTPUT
+          echo "LOCAL_CACHE_IMAGE_TAG=app:cache" >> $GITHUB_OUTPUT
 
           PROJECTS="${{ inputs.ecr_repository }}"
           if [ "${{ inputs.projects }}" != "" ]; then
@@ -236,10 +236,10 @@ jobs:
           COMMON="--target development --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.CACHE_IMAGE_TAG }} "
 
           if [ "${{ steps.env2.outputs.USE_BUILDX }}" == "true" ]; then
-            BUILD_TEST_COMMAND="docker buildx build --platform=${{ inputs.platforms }} $COMMON -t ${{ steps.env2.outputs.CACHE_IMAGE_TAG }} -t ${{ steps.env2.outputs.LOCAL_IMAGE_TAG }} ."
+            BUILD_TEST_COMMAND="docker buildx build --platform=${{ inputs.platforms }} $COMMON -t ${{ steps.env2.outputs.CACHE_IMAGE_TAG }} -t ${{ steps.env2.outputs.LOCAL_CACHE_IMAGE_TAG }} ."
           else
             docker pull ${{ steps.env2.outputs.CACHE_IMAGE_TAG }} || echo "true"
-            BUILD_TEST_COMMAND="docker build $COMMON -t ${{ steps.env2.outputs.CACHE_IMAGE_TAG }} -t ${{ steps.env2.outputs.LOCAL_IMAGE_TAG }} ."
+            BUILD_TEST_COMMAND="docker build $COMMON -t ${{ steps.env2.outputs.CACHE_IMAGE_TAG }} -t ${{ steps.env2.outputs.LOCAL_CACHE_IMAGE_TAG }} ."
           fi
 
           BUILDX_PUSH_TEST_COMMAND="docker buildx build --push --platform=${{ inputs.platforms }} $COMMON -t ${{ steps.env2.outputs.CACHE_IMAGE_TAG }} ."
@@ -247,7 +247,7 @@ jobs:
 
           ## Note this is only needed as buildx doesnt support --load with multiple platforms yet but is on roadmap
           ## if it is ever supported simply remove this and the "Load test oci image step" and add --load to the first BUILD_TEST_COMMAND
-          BUILDX_LOAD_TEST_COMMAND="docker buildx build --load $COMMON -t ${{ steps.env2.outputs.LOCAL_IMAGE_TAG }} ."
+          BUILDX_LOAD_TEST_COMMAND="docker buildx build --load $COMMON -t ${{ steps.env2.outputs.LOCAL_CACHE_IMAGE_TAG }} ."
           echo "BUILDX_LOAD_TEST_COMMAND=$BUILDX_LOAD_TEST_COMMAND" >> $GITHUB_OUTPUT
 
           DOCKER_BUILDKIT=1 $BUILD_TEST_COMMAND
@@ -293,7 +293,7 @@ jobs:
           IMAGE_SCANNER_COMMON="docker run -u 0 -v /var/run/docker.sock:/var/run/docker.sock -v ${PWD}/Dockerfile:/app/Dockerfile ${{ steps.env2.outputs.IMAGE_SCANNER_IMAGE_TAG }}"
           echo "IMAGE_SCANNER_COMMON=$IMAGE_SCANNER_COMMON" >> $GITHUB_OUTPUT
 
-          export EXTRA_TASK_IMAGE_LINT_COMMAND="$IMAGE_SCANNER_COMMON ./scripts/lint ${{ steps.env2.outputs.LOCAL_IMAGE_TAG }} /app/Dockerfile ${{ inputs.supress_task_failures }}"
+          export EXTRA_TASK_IMAGE_LINT_COMMAND="$IMAGE_SCANNER_COMMON ./scripts/lint ${{ steps.env2.outputs.LOCAL_CACHE_IMAGE_TAG }} /app/Dockerfile ${{ inputs.supress_task_failures }}"
 
           ./.github/reusable_workflow/scripts/additional_tasks.sh
 

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -3,7 +3,7 @@ on:
   workflow_call:
     inputs:
       # If not provided then assumes auto generated stable-SHA256
-      image_tag:
+      override_image_tag:
         default: ""
         type: string
       # currently only supresses image scans/lints, but can be expanded if needed
@@ -145,8 +145,8 @@ jobs:
           fi
           echo "BRANCH_NAME=$branch_name" >> $GITHUB_OUTPUT
 
-          if [ "${{ inputs.image_tag }}" != "" ]; then
-            image_tag="${{ inputs.image_tag }}"
+          if [ "${{ inputs.override_image_tag }}" != "" ]; then
+            image_tag="${{ inputs.override_image_tag }}"
           elif [ "${{ inputs.event_name }}" == "issue_comment" ]; then
             image_tag=adhoc-${{steps.comment-branch.outputs.head_ref}}-${{steps.comment-branch.outputs.head_sha}}
           else
@@ -354,17 +354,18 @@ jobs:
         if: inputs.event_name != 'issue_comment' && always()
         run: cat image_lint.txt || (cat image_lint_error.txt && exit 1)
 
-      - name: Run Image scan on production image for cves
-        if: inputs.event_name != 'issue_comment'
-        run: |
-          image_sha="$(docker images --no-trunc --quiet ${{ steps.env2.outputs.PRODUCTION_IMAGE_ID_TAG }})"
-          ${{ steps.build-production.outputs.IMAGE_SCANNER_COMMON }} \
-            ./scripts/scan \
-            ${{ steps.env2.outputs.PRODUCTION_IMAGE_ID_TAG }} \
-            $image_sha \
-            /app/Dockerfile \
-            ${{ secrets.SNYK_TOKEN }} \
-            ${{ inputs.supress_task_failures }}
+      # TODO: comment out for now, can we move to a more async job approuch?
+      # - name: Run Image scan on production image for cves
+      #   if: inputs.event_name != 'issue_comment'
+      #   run: |
+      #     image_sha="$(docker images --no-trunc --quiet ${{ steps.env2.outputs.PRODUCTION_IMAGE_ID_TAG }})"
+      #     ${{ steps.build-production.outputs.IMAGE_SCANNER_COMMON }} \
+      #       ./scripts/scan \
+      #       ${{ steps.env2.outputs.PRODUCTION_IMAGE_ID_TAG }} \
+      #       $image_sha \
+      #       /app/Dockerfile \
+      #       ${{ secrets.SNYK_TOKEN }} \
+      #       ${{ inputs.supress_task_failures }}
 
       - name: Push to ECR
         run: |

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -354,17 +354,17 @@ jobs:
         if: inputs.event_name != 'issue_comment' && always()
         run: cat image_lint.txt || (cat image_lint_error.txt && exit 1)
 
-      # - name: Run Image scan on production image for cves
-      #   if: inputs.event_name != 'issue_comment'
-      #   run: |
-      #     image_sha="$(docker images --no-trunc --quiet ${{ steps.env2.outputs.PRODUCTION_IMAGE_TAG }})"
-      #     ${{ steps.build-production.outputs.IMAGE_SCANNER_COMMON }} \
-      #       ./scripts/scan \
-      #       ${{ steps.env2.outputs.PRODUCTION_IMAGE_TAG }} \
-      #       $image_sha \
-      #       /app/Dockerfile \
-      #       ${{ secrets.SNYK_TOKEN }} \
-      #       ${{ inputs.supress_task_failures }}
+      - name: Run Image scan on production image for cves
+        if: inputs.event_name != 'issue_comment'
+        run: |
+          image_sha="$(docker images --no-trunc --quiet ${{ steps.env2.outputs.PRODUCTION_IMAGE_TAG }})"
+          ${{ steps.build-production.outputs.IMAGE_SCANNER_COMMON }} \
+            ./scripts/scan \
+            ${{ steps.env2.outputs.PRODUCTION_IMAGE_TAG }} \
+            $image_sha \
+            /app/Dockerfile \
+            ${{ secrets.SNYK_TOKEN }} \
+            ${{ inputs.supress_task_failures }}
 
       - name: Push to ECR
         run: |

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -108,12 +108,12 @@ jobs:
         ports:
           - "3306:3306"
     steps:
-      - uses: xt0rted/pull-request-comment-branch@d97294d304604fa98a2600a6e2f916a84b596dc7 # v2
+      - uses: xt0rted/pull-request-comment-branch@d97294d304604fa98a2600a6e2f916a84b596dc7 # v2.0.0
         if: inputs.event_name == 'issue_comment'
         id: comment-branch
 
       - name: Set commit status as pending
-        uses: myrotvorets/set-commit-status-action@master
+        uses: myrotvorets/set-commit-status-action@38f3f27c7d52fb381273e95542f07f0fba301307 # v2.0.0
         if: inputs.event_name == 'issue_comment'
         with:
           sha: ${{ steps.comment-branch.outputs.head_sha }}
@@ -145,12 +145,12 @@ jobs:
           image_tag=$(echo "$image_tag" | tr / _)
           echo "IMAGE_TAG=$image_tag" >> $GITHUB_OUTPUT
 
-      - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5 # v2
+      - uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
         with:
           ref: ${{ steps.env1.outputs.BRANCH_NAME }}
 
       - name: Checkout reusable workflow dir
-        uses: actions/checkout@c85c95e3d7251135ab7dc9ce3241c5835cc595a9 # v3
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4.1.0
         with:
           repository: ausaccessfed/workflows
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -166,30 +166,35 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@2f9f10ea3fa2eed41ac443fee8bfbd059af2d0a4 # v1
+        uses: aws-actions/amazon-ecr-login@2f9f10ea3fa2eed41ac443fee8bfbd059af2d0a4 # v1.6.0
 
       - name: set more envs
         id: env2
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: |
+          echo "ECR_REGISTRY=$ECR_REGISTRY" >> $GITHUB_OUTPUT
+
           VERSION=$(${{ inputs.version_command }})
           BASE_IMAGE="${{ secrets.DOCKER_ECR }}ruby-base:${VERSION}"
           echo "BASE_IMAGE=$BASE_IMAGE" >> $GITHUB_OUTPUT
+
           # Strip git ref prefix from version
           IMAGE_ID=$(echo "$ECR_REGISTRY/${{ inputs.ecr_repository }}" | tr '[A-Z]' '[a-z]')
-          echo "ECR_REGISTRY=$ECR_REGISTRY" >> $GITHUB_OUTPUT
           echo "IMAGE_ID=$IMAGE_ID" >> $GITHUB_OUTPUT
+
           PROJECTS="${{ inputs.ecr_repository }}"
           if [ "${{ inputs.projects }}" != "" ]; then
             PROJECTS="${{ inputs.projects }}"
           fi
           echo "PROJECTS=$PROJECTS" >> $GITHUB_OUTPUT
+
           DEFAULT_BRANCH_FOR_CACHING="${{ inputs.default_branch_for_caching }}"
           if [ "$DEFAULT_BRANCH_FOR_CACHING" == "" ]; then
             DEFAULT_BRANCH_FOR_CACHING="${{ inputs.default_branch }}"
           fi
           echo "DEFAULT_BRANCH_FOR_CACHING=$DEFAULT_BRANCH_FOR_CACHING" >> $GITHUB_OUTPUT
+
           USE_BUILDX="false"
           if [ "${{ inputs.platforms }}" != "" ]; then
             USE_BUILDX="true"
@@ -198,11 +203,11 @@ jobs:
 
       - name: Set up QEMU
         if: steps.env2.outputs.USE_BUILDX == 'true'
-        uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480 # v1
+        uses: docker/setup-qemu-action@27d0a4f181a40b142cce983c5393082c365d1480 # v1.2.0
 
       - name: Set up Docker Buildx
         if: steps.env2.outputs.USE_BUILDX == 'true'
-        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 # v1
+        uses: docker/setup-buildx-action@f211e3e9ded2d9377c8cadc4489a4e38014bc4c9 # v1.7.0
 
       - name: Build Test OCI Image
         id: build-test
@@ -361,7 +366,10 @@ jobs:
       ## no point making the gitops repo triggers async, they will fight each other
       ## and usually only 1 if statement is called anyway
       - name: Update GitOps Repo to trigger deploys
-        if: steps.env1.outputs.BRANCH_NAME == inputs.default_branch &&  inputs.event_name == 'push'
+        if: |
+          inputs.production_environments != '' && 
+          steps.env1.outputs.BRANCH_NAME == inputs.default_branch && 
+          inputs.event_name == 'push'
         run: |
           printenv > .envs
            docker run --env-file .envs \
@@ -372,7 +380,10 @@ jobs:
            ${{ steps.env2.outputs.ECR_REGISTRY }}/publish_app:latest
 
       - name: Update GitOps Repo to trigger deploys for test
-        if: inputs.test_environments != '' && inputs.default_develop_branch != '' && steps.env1.outputs.BRANCH_NAME == inputs.default_develop_branch &&  inputs.event_name == 'push'
+        if: |
+          inputs.test_environments != '' && 
+          steps.env1.outputs.BRANCH_NAME == inputs.default_develop_branch && 
+          inputs.event_name == 'push'
         run: |
           printenv > .envs
            docker run --env-file .envs \
@@ -383,7 +394,9 @@ jobs:
            ${{ steps.env2.outputs.ECR_REGISTRY }}/publish_app:latest
 
       - name: Update GitOps Repo to trigger deploys for development
-        if: inputs.event_name == 'issue_comment'
+        if: |
+          inputs.development_environments != '' &&
+          inputs.event_name == 'issue_comment'
         run: |
           printenv > .envs
            docker run --env-file .envs \
@@ -429,7 +442,7 @@ jobs:
 
       - name: Set final commit status
         if: inputs.event_name == 'issue_comment' && always()
-        uses: myrotvorets/set-commit-status-action@master
+        uses: myrotvorets/set-commit-status-action@38f3f27c7d52fb381273e95542f07f0fba301307 # v2.0.0
         with:
           sha: ${{ steps.comment-branch.outputs.head_sha }}
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -296,9 +296,8 @@ jobs:
         id: build-production-result
         if: always()
         run: |
-          cat build.txt 2>/dev/null
-          cat build_error.txt 2>/dev/null
-          ([[ -f build_error.txt ]] || [[ ! -f build.txt ]]) && exit 1
+          cat build.txt 
+          [[ -f build_error.txt ]] && cat build_error.txt && exit 1 ||  echo ""
 
       - name: ${{ inputs.extra_task_1_name }} Result
         id: extra-task-1

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -298,7 +298,7 @@ jobs:
         run: |
           cat build.txt 2>/dev/null || echo ""
           cat build_error.txt 2>/dev/null || echo ""
-          ([[ -f build_error.txt -o ! -f build.txt ]]) && exit 1
+          ([ -f build_error.txt -o ! -f build.txt ]) && exit 1
 
       - name: ${{ inputs.extra_task_1_name }} Result
         id: extra-task-1
@@ -308,7 +308,7 @@ jobs:
         run: |
           cat task_$TASK_NUM.txt 2>/dev/null || echo ""
           cat task_$TASK_NUM_error.txt 2>/dev/null || echo ""
-          ([[ -f task_$TASK_NUM_error.txt -o ! -f task_$TASK_NUM.txt ]]) && exit 1
+          ([ -f task_$TASK_NUM_error.txt -o ! -f task_$TASK_NUM.txt ]) && exit 1
 
       - name: ${{ inputs.extra_task_2_name }} Result
         id: extra-task-2
@@ -318,7 +318,7 @@ jobs:
         run: |
           cat task_$TASK_NUM.txt 2>/dev/null || echo ""
           cat task_$TASK_NUM_error.txt 2>/dev/null || echo ""
-          ([[ -f task_$TASK_NUM_error.txt -o ! -f task_$TASK_NUM.txt ]]) && exit 1
+          ([ -f task_$TASK_NUM_error.txt -o ! -f task_$TASK_NUM.txt ]) && exit 1
 
       - name: ${{ inputs.extra_task_3_name }} Result
         id: extra-task-3
@@ -328,7 +328,7 @@ jobs:
         run: |
           cat task_$TASK_NUM.txt 2>/dev/null || echo ""
           cat task_$TASK_NUM_error.txt 2>/dev/null || echo ""
-          ([[ -f task_$TASK_NUM_error.txt -o ! -f task_$TASK_NUM.txt ]]) && exit 1
+          ([ -f task_$TASK_NUM_error.txt -o ! -f task_$TASK_NUM.txt ]) && exit 1
 
       - name: ${{ inputs.extra_task_4_name }} Result
         id: extra-task-4
@@ -338,7 +338,7 @@ jobs:
         run: |
           cat task_$TASK_NUM.txt 2>/dev/null || echo ""
           cat task_$TASK_NUM_error.txt 2>/dev/null || echo ""
-          ([[ -f task_$TASK_NUM_error.txt -o ! -f task_$TASK_NUM.txt ]]) && exit 1
+          ([ -f task_$TASK_NUM_error.txt -o ! -f task_$TASK_NUM.txt ]) && exit 1
 
       - name: ${{ inputs.extra_task_5_name }} Result
         id: extra-task-5
@@ -348,7 +348,7 @@ jobs:
         run: |
           cat task_$TASK_NUM.txt 2>/dev/null || echo ""
           cat task_$TASK_NUM_error.txt 2>/dev/null || echo ""
-          ([[ -f task_$TASK_NUM_error.txt -o ! -f task_$TASK_NUM.txt ]]) && exit 1
+          ([ -f task_$TASK_NUM_error.txt -o ! -f task_$TASK_NUM.txt ]) && exit 1
 
       - name: ${{ inputs.extra_task_6_name }} Result
         id: extra-task-6
@@ -358,7 +358,7 @@ jobs:
         run: |
           cat task_$TASK_NUM.txt 2>/dev/null || echo ""
           cat task_$TASK_NUM_error.txt 2>/dev/null || echo ""
-          ([[ -f task_$TASK_NUM_error.txt -o ! -f task_$TASK_NUM.txt ]]) && exit 1
+          ([ -f task_$TASK_NUM_error.txt -o ! -f task_$TASK_NUM.txt ]) && exit 1
 
       - name: Image lint results
         id: image-lint
@@ -366,7 +366,7 @@ jobs:
         run: |
           cat image_lint.txt 2>/dev/null || echo ""
           cat image_lint_error.txt 2>/dev/null || echo ""
-          ([[ -f image_lint_error.txt -o ! -f image_lint.txt ]]) && exit 1
+          ([ -f image_lint_error.txt -o ! -f image_lint.txt ]) && exit 1
 
       - name: Run Image scan on production image for cves
         if: inputs.event_name != 'issue_comment'

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -348,7 +348,7 @@ jobs:
       - name: Run Image scan on production image for cves
         if: inputs.event_name != 'issue_comment'
         run: |
-          SCAN_COMMAND="./scripts/scan '${{ steps.env1.outputs.IMAGE_TAG }}' '$(shell docker images --no-trunc --quiet ${{ steps.env1.outputs.IMAGE_TAG }})' '/app/repo/Dockerfile' '${{ secrets.SNYK_TOKEN }}'"
+          SCAN_COMMAND="./scripts/scan '${{ steps.env1.outputs.IMAGE_TAG }}' '$(docker images --no-trunc --quiet ${{ steps.env1.outputs.IMAGE_TAG }})' '/app/repo/Dockerfile' '${{ secrets.SNYK_TOKEN }}'"
           $("${{ steps.build-production.outputs.IMAGE_SCANNER_COMMON }} $SCAN_COMMAND")
 
       - name: Push to ECR

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -296,68 +296,54 @@ jobs:
       - name: Build Production Result
         id: build-production-result
         if: always()
-        run: |
-          cat build.txt || (cat build_error.txt && exit 1)
+        run: cat build.txt || (cat build_error.txt && exit 1)
 
       - name: ${{ inputs.extra_task_1_name }} Result
         id: extra-task-1
         if: inputs.event_name != 'issue_comment' && inputs.extra_task_1 != '' && always()
         env:
           NUMBER: 1
-        run: |
-          cat task_${NUMBER}.txt 
-          [[ -f task_${NUMBER}_error.txt ]] && cat task_${NUMBER}_error.txt && exit 1 ||  echo ""
+        run: cat task_${NUMBER}.txt || (cat task_${NUMBER}_error.txt && exit 1)
 
       - name: ${{ inputs.extra_task_2_name }} Result
         id: extra-task-2
         if: inputs.event_name != 'issue_comment' && inputs.extra_task_2 != '' && always()
         env:
           NUMBER: 2
-        run: |
-          cat task_${NUMBER}.txt 
-          [[ -f task_${NUMBER}_error.txt ]] && cat task_${NUMBER}_error.txt && exit 1 ||  echo ""
+        run: cat task_${NUMBER}.txt || (cat task_${NUMBER}_error.txt && exit 1)
 
       - name: ${{ inputs.extra_task_3_name }} Result
         id: extra-task-3
         if: inputs.event_name != 'issue_comment' && inputs.extra_task_3 != '' && always()
         env:
           NUMBER: 3
-        run: |
-          cat task_${NUMBER}.txt 
-          [[ -f task_${NUMBER}_error.txt ]] && cat task_${NUMBER}_error.txt && exit 1 ||  echo ""
+        run: cat task_${NUMBER}.txt || (cat task_${NUMBER}_error.txt && exit 1)
 
       - name: ${{ inputs.extra_task_4_name }} Result
         id: extra-task-4
         if: inputs.event_name != 'issue_comment' && inputs.extra_task_4 != '' && always()
         env:
           NUMBER: 4
-        run: |
-          cat task_${NUMBER}.txt 
-          [[ -f task_${NUMBER}_error.txt ]] && cat task_${NUMBER}_error.txt && exit 1 ||  echo ""
+        run: cat task_${NUMBER}.txt || (cat task_${NUMBER}_error.txt && exit 1)
 
       - name: ${{ inputs.extra_task_5_name }} Result
         id: extra-task-5
         if: inputs.event_name != 'issue_comment' && inputs.extra_task_5 != '' && always()
         env:
           NUMBER: 5
-        run: |
-          cat task_${NUMBER}.txt 
-          [[ -f task_${NUMBER}_error.txt ]] && cat task_${NUMBER}_error.txt && exit 1 ||  echo ""
+        run: cat task_${NUMBER}.txt || (cat task_${NUMBER}_error.txt && exit 1)
 
       - name: ${{ inputs.extra_task_6_name }} Result
         id: extra-task-6
         if: inputs.event_name != 'issue_comment' && inputs.extra_task_6 != '' && always()
         env:
           NUMBER: 6
-        run: |
-          cat task_${NUMBER}.txt 
-          [[ -f task_${NUMBER}_error.txt ]] && cat task_${NUMBER}_error.txt && exit 1 ||  echo ""
+        run: cat task_${NUMBER}.txt || (cat task_${NUMBER}_error.txt && exit 1)
 
       - name: Image lint results
         id: image-lint
         if: inputs.event_name != 'issue_comment' && always()
-        run: |
-          cat image_lint.txt || (cat image_lint_error.txt && exit 1)
+        run: cat image_lint.txt || (cat image_lint_error.txt && exit 1)
 
       - name: Run Image scan on production image for cves
         if: inputs.event_name != 'issue_comment'

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -354,17 +354,17 @@ jobs:
         if: inputs.event_name != 'issue_comment' && always()
         run: cat image_lint.txt || (cat image_lint_error.txt && exit 1)
 
-      - name: Run Image scan on production image for cves
-        if: inputs.event_name != 'issue_comment'
-        run: |
-          image_sha="$(docker images --no-trunc --quiet ${{ steps.env2.outputs.PRODUCTION_IMAGE_TAG }})"
-          ${{ steps.build-production.outputs.IMAGE_SCANNER_COMMON }} \
-            ./scripts/scan \
-            ${{ steps.env2.outputs.PRODUCTION_IMAGE_TAG }} \
-            $image_sha \
-            /app/Dockerfile \
-            ${{ secrets.SNYK_TOKEN }} \
-            ${{ inputs.supress_task_failures }}
+      # - name: Run Image scan on production image for cves
+      #   if: inputs.event_name != 'issue_comment'
+      #   run: |
+      #     image_sha="$(docker images --no-trunc --quiet ${{ steps.env2.outputs.PRODUCTION_IMAGE_TAG }})"
+      #     ${{ steps.build-production.outputs.IMAGE_SCANNER_COMMON }} \
+      #       ./scripts/scan \
+      #       ${{ steps.env2.outputs.PRODUCTION_IMAGE_TAG }} \
+      #       $image_sha \
+      #       /app/Dockerfile \
+      #       ${{ secrets.SNYK_TOKEN }} \
+      #       ${{ inputs.supress_task_failures }}
 
       - name: Push to ECR
         run: |

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -296,57 +296,77 @@ jobs:
         id: build-production-result
         if: always()
         run: |
-          cat build.txt || echo ""
-          [[ -f build_error.txt ]] && cat build_error.txt && exit 1 || echo ""
+          cat build.txt 2>/dev/null
+          cat build_error.txt 2>/dev/null
+          ([[ -f build_error.txt ]] || [[ ! -f build.txt ]]) && exit 1
 
       - name: ${{ inputs.extra_task_1_name }} Result
         id: extra-task-1
         if: inputs.event_name != 'issue_comment' && inputs.extra_task_1 != '' && always()
+        env:
+          TASK_NUM: 1
         run: |
-          cat task_1.txt || echo ""
-          [[ -f task_1_error.txt ]] && cat task_1_error.txt && exit 1 ||  echo ""
+          cat task_$TASK_NUM.txt 2>/dev/null
+          cat task_$TASK_NUM_error.txt 2>/dev/null
+          ([[ -f task_$TASK_NUM_error.txt ]] || [[ ! -f task_$TASK_NUM.txt ]]) && exit 1
 
       - name: ${{ inputs.extra_task_2_name }} Result
         id: extra-task-2
         if: inputs.event_name != 'issue_comment' && inputs.extra_task_2 != '' && always()
+        env:
+          TASK_NUM: 2
         run: |
-          cat task_2.txt || echo ""
-          [[ -f task_2_error.txt ]] && cat task_2_error.txt && exit 1 ||  echo ""
+          cat task_$TASK_NUM.txt 2>/dev/null
+          cat task_$TASK_NUM_error.txt 2>/dev/null
+          ([[ -f task_$TASK_NUM_error.txt ]] || [[ ! -f task_$TASK_NUM.txt ]]) && exit 1
 
       - name: ${{ inputs.extra_task_3_name }} Result
         id: extra-task-3
         if: inputs.event_name != 'issue_comment' && inputs.extra_task_3 != '' && always()
+        env:
+          TASK_NUM: 3
         run: |
-          cat task_3.txt || echo "" 
-          [[ -f task_3_error.txt ]] && cat task_3_error.txt && exit 1 ||  echo ""
+          cat task_$TASK_NUM.txt 2>/dev/null
+          cat task_$TASK_NUM_error.txt 2>/dev/null
+          ([[ -f task_$TASK_NUM_error.txt ]] || [[ ! -f task_$TASK_NUM.txt ]]) && exit 1
 
       - name: ${{ inputs.extra_task_4_name }} Result
         id: extra-task-4
         if: inputs.event_name != 'issue_comment' && inputs.extra_task_4 != '' && always()
+        env:
+          TASK_NUM: 4
         run: |
-          cat task_4.txt || echo "" 
-          [[ -f task_4_error.txt ]] && cat task_4_error.txt && exit 1 ||  echo ""
+          cat task_$TASK_NUM.txt 2>/dev/null
+          cat task_$TASK_NUM_error.txt 2>/dev/null
+          ([[ -f task_$TASK_NUM_error.txt ]] || [[ ! -f task_$TASK_NUM.txt ]]) && exit 1
 
       - name: ${{ inputs.extra_task_5_name }} Result
         id: extra-task-5
         if: inputs.event_name != 'issue_comment' && inputs.extra_task_5 != '' && always()
+        env:
+          TASK_NUM: 5
         run: |
-          cat task_5.txt  || echo ""
-          [[ -f task_5_error.txt ]] && cat task_5_error.txt && exit 1 ||  echo ""
+          cat task_$TASK_NUM.txt 2>/dev/null
+          cat task_$TASK_NUM_error.txt 2>/dev/null
+          ([[ -f task_$TASK_NUM_error.txt ]] || [[ ! -f task_$TASK_NUM.txt ]]) && exit 1
 
       - name: ${{ inputs.extra_task_6_name }} Result
         id: extra-task-6
         if: inputs.event_name != 'issue_comment' && inputs.extra_task_6 != '' && always()
+        env:
+          TASK_NUM: 6
         run: |
-          cat task_6.txt || echo ""
-          [[ -f task_6_error.txt ]] && cat task_6_error.txt && exit 1 ||  echo ""
+          cat task_$TASK_NUM.txt 2>/dev/null
+          cat task_$TASK_NUM_error.txt 2>/dev/null
+          ([[ -f task_$TASK_NUM_error.txt ]] || [[ ! -f task_$TASK_NUM.txt ]]) && exit 1
 
       - name: Image lint results
         id: image-lint
         if: inputs.event_name != 'issue_comment' && always()
         run: |
-          cat image_lint.txt || echo ""
-          [[ -f image_lint_error.txt ]] && cat image_lint_error.txt && exit 1 ||  echo ""
+          cat image_lint.txt 2>/dev/null
+          cat image_lint_error.txt 2>/dev/null
+          ([[ -f image_lint_error.txt ]] || [[ ! -f image_lint.txt ]]) && exit 1
 
       - name: Run Image scan on production image for cves
         if: inputs.event_name != 'issue_comment'

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -2,6 +2,9 @@ name: Build Docker Image
 on:
   workflow_call:
     inputs:
+      hardcoded_image_tag:
+        default: ""
+        type: string
       ecr_repository:
         required: true
         type: string
@@ -132,7 +135,9 @@ jobs:
           fi
           echo "BRANCH_NAME=$branch_name" >> $GITHUB_OUTPUT
 
-          if [ "${{ inputs.event_name }}" == "issue_comment" ]; then
+          if [ "${{ inputs.hardcoded_image_tag }}" != "" ]; then
+            image_tag="${{ inputs.hardcoded_image_tag }}"
+          elif [ "${{ inputs.event_name }}" == "issue_comment" ]; then
             image_tag=adhoc-${{steps.comment-branch.outputs.head_ref}}-${{steps.comment-branch.outputs.head_sha}}
           else
             image_tag=stable-${{ github.sha }}

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -185,8 +185,8 @@ jobs:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
         run: |
           echo "ECR_REGISTRY=$ECR_REGISTRY" >> $GITHUB_OUTPUT
-          echo "PUBLISH_APP_IMAGE_TAG=$ECR_REGISTRY/publish_app:latest" >> $GITHUB_OUTPUT
-          echo "IMAGE_SCANNER_IMAGE_TAG=$ECR_REGISTRY/image-scanner:latest" >> $GITHUB_OUTPUT
+          echo "PUBLISH_APP_IMAGE_ID_TAG=$ECR_REGISTRY/publish_app:latest" >> $GITHUB_OUTPUT
+          echo "IMAGE_SCANNER_IMAGE_ID_TAG=$ECR_REGISTRY/image-scanner:latest" >> $GITHUB_OUTPUT
 
           VERSION=$(${{ inputs.version_command }})
           BASE_IMAGE="${{ secrets.DOCKER_ECR }}ruby-base:${VERSION}"
@@ -196,12 +196,12 @@ jobs:
           IMAGE_ID=$(echo "$ECR_REGISTRY/${{ inputs.ecr_repository }}" | tr '[A-Z]' '[a-z]')
           echo "IMAGE_ID=$IMAGE_ID" >> $GITHUB_OUTPUT
 
-          echo "PRODUCTION_IMAGE_TAG=$IMAGE_ID:${{ steps.env1.outputs.IMAGE_TAG }}" >> $GITHUB_OUTPUT
+          echo "PRODUCTION_IMAGE_ID_TAG=$IMAGE_ID:${{ steps.env1.outputs.IMAGE_TAG }}" >> $GITHUB_OUTPUT
 
-          echo "CACHE_IMAGE_TAG=$IMAGE_ID:cache" >> $GITHUB_OUTPUT
+          echo "CACHE_IMAGE_ID_TAG=$IMAGE_ID:cache" >> $GITHUB_OUTPUT
 
           # This is just a image tag without ecr to avoid ever grabbing from ecr
-          echo "LOCAL_CACHE_IMAGE_TAG=app:cache" >> $GITHUB_OUTPUT
+          echo "LOCAL_CACHE_IMAGE_ID_TAG=app:cache" >> $GITHUB_OUTPUT
 
           PROJECTS="${{ inputs.ecr_repository }}"
           if [ "${{ inputs.projects }}" != "" ]; then
@@ -233,21 +233,21 @@ jobs:
         id: build-test
         run: |
           BUILD_TEST_COMMAND=""
-          COMMON="--target development --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.CACHE_IMAGE_TAG }} "
+          COMMON="--target development --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.CACHE_IMAGE_ID_TAG }} "
 
           if [ "${{ steps.env2.outputs.USE_BUILDX }}" == "true" ]; then
-            BUILD_TEST_COMMAND="docker buildx build --platform=${{ inputs.platforms }} $COMMON -t ${{ steps.env2.outputs.CACHE_IMAGE_TAG }} -t ${{ steps.env2.outputs.LOCAL_CACHE_IMAGE_TAG }} ."
+            BUILD_TEST_COMMAND="docker buildx build --platform=${{ inputs.platforms }} $COMMON -t ${{ steps.env2.outputs.CACHE_IMAGE_ID_TAG }} -t ${{ steps.env2.outputs.LOCAL_CACHE_IMAGE_ID_TAG }} ."
           else
-            docker pull ${{ steps.env2.outputs.CACHE_IMAGE_TAG }} || echo "true"
-            BUILD_TEST_COMMAND="docker build $COMMON -t ${{ steps.env2.outputs.CACHE_IMAGE_TAG }} -t ${{ steps.env2.outputs.LOCAL_CACHE_IMAGE_TAG }} ."
+            docker pull ${{ steps.env2.outputs.CACHE_IMAGE_ID_TAG }} || echo "true"
+            BUILD_TEST_COMMAND="docker build $COMMON -t ${{ steps.env2.outputs.CACHE_IMAGE_ID_TAG }} -t ${{ steps.env2.outputs.LOCAL_CACHE_IMAGE_ID_TAG }} ."
           fi
 
-          BUILDX_PUSH_TEST_COMMAND="docker buildx build --push --platform=${{ inputs.platforms }} $COMMON -t ${{ steps.env2.outputs.CACHE_IMAGE_TAG }} ."
+          BUILDX_PUSH_TEST_COMMAND="docker buildx build --push --platform=${{ inputs.platforms }} $COMMON -t ${{ steps.env2.outputs.CACHE_IMAGE_ID_TAG }} ."
           echo "BUILDX_PUSH_TEST_COMMAND=$BUILDX_PUSH_TEST_COMMAND" >> $GITHUB_OUTPUT
 
           ## Note this is only needed as buildx doesnt support --load with multiple platforms yet but is on roadmap
           ## if it is ever supported simply remove this and the "Load test oci image step" and add --load to the first BUILD_TEST_COMMAND
-          BUILDX_LOAD_TEST_COMMAND="docker buildx build --load $COMMON -t ${{ steps.env2.outputs.LOCAL_CACHE_IMAGE_TAG }} ."
+          BUILDX_LOAD_TEST_COMMAND="docker buildx build --load $COMMON -t ${{ steps.env2.outputs.LOCAL_CACHE_IMAGE_ID_TAG }} ."
           echo "BUILDX_LOAD_TEST_COMMAND=$BUILDX_LOAD_TEST_COMMAND" >> $GITHUB_OUTPUT
 
           DOCKER_BUILDKIT=1 $BUILD_TEST_COMMAND
@@ -261,7 +261,7 @@ jobs:
         id: build-production
         run: |
           BUILD_PRODUCTION_COMMAND=""
-          COMMON="--target production --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg RELEASE_VERSION=${{ steps.env1.outputs.IMAGE_TAG }} --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.CACHE_IMAGE_TAG }} -t ${{ steps.env2.outputs.PRODUCTION_IMAGE_TAG }}"
+          COMMON="--target production --build-arg BUILDKIT_INLINE_CACHE=1 --build-arg RELEASE_VERSION=${{ steps.env1.outputs.IMAGE_TAG }} --build-arg BASE_IMAGE=${{ steps.env2.outputs.BASE_IMAGE }}  --cache-from ${{ steps.env2.outputs.CACHE_IMAGE_ID_TAG }} -t ${{ steps.env2.outputs.PRODUCTION_IMAGE_ID_TAG }}"
           if [ "${{ steps.env2.outputs.USE_BUILDX }}" == "true" ]; then
             BUILD_PRODUCTION_COMMAND="docker buildx build --platform=${{ inputs.platforms }} $COMMON ."
           else
@@ -290,10 +290,10 @@ jobs:
           fi
 
           # must run as root to access the docker socket
-          IMAGE_SCANNER_COMMON="docker run -u 0 -v /var/run/docker.sock:/var/run/docker.sock -v ${PWD}/Dockerfile:/app/Dockerfile ${{ steps.env2.outputs.IMAGE_SCANNER_IMAGE_TAG }}"
+          IMAGE_SCANNER_COMMON="docker run -u 0 -v /var/run/docker.sock:/var/run/docker.sock -v ${PWD}/Dockerfile:/app/Dockerfile ${{ steps.env2.outputs.IMAGE_SCANNER_IMAGE_ID_TAG }}"
           echo "IMAGE_SCANNER_COMMON=$IMAGE_SCANNER_COMMON" >> $GITHUB_OUTPUT
 
-          export EXTRA_TASK_IMAGE_LINT_COMMAND="$IMAGE_SCANNER_COMMON ./scripts/lint ${{ steps.env2.outputs.LOCAL_CACHE_IMAGE_TAG }} /app/Dockerfile ${{ inputs.supress_task_failures }}"
+          export EXTRA_TASK_IMAGE_LINT_COMMAND="$IMAGE_SCANNER_COMMON ./scripts/lint ${{ steps.env2.outputs.LOCAL_CACHE_IMAGE_ID_TAG }} /app/Dockerfile ${{ inputs.supress_task_failures }}"
 
           ./.github/reusable_workflow/scripts/additional_tasks.sh
 
@@ -357,10 +357,10 @@ jobs:
       - name: Run Image scan on production image for cves
         if: inputs.event_name != 'issue_comment'
         run: |
-          image_sha="$(docker images --no-trunc --quiet ${{ steps.env2.outputs.PRODUCTION_IMAGE_TAG }})"
+          image_sha="$(docker images --no-trunc --quiet ${{ steps.env2.outputs.PRODUCTION_IMAGE_ID_TAG }})"
           ${{ steps.build-production.outputs.IMAGE_SCANNER_COMMON }} \
             ./scripts/scan \
-            ${{ steps.env2.outputs.PRODUCTION_IMAGE_TAG }} \
+            ${{ steps.env2.outputs.PRODUCTION_IMAGE_ID_TAG }} \
             $image_sha \
             /app/Dockerfile \
             ${{ secrets.SNYK_TOKEN }} \
@@ -378,7 +378,7 @@ jobs:
             if [ "${{ steps.env2.outputs.USE_BUILDX }}" == "true" ]; then
               export PRODUCTION_PUSH_COMMAND="${{ steps.build-production.outputs.BUILDX_PUSH_PRODUCTION_COMMAND }}"
             else 
-              export PRODUCTION_PUSH_COMMAND="docker push ${{ steps.env2.outputs.PRODUCTION_IMAGE_TAG }}"
+              export PRODUCTION_PUSH_COMMAND="docker push ${{ steps.env2.outputs.PRODUCTION_IMAGE_ID_TAG }}"
             fi
           fi
 
@@ -386,7 +386,7 @@ jobs:
             if [ "${{ steps.env2.outputs.USE_BUILDX }}" == "true" ]; then
               export CACHE_PUSH_COMMAND="${{ steps.build-test.outputs.BUILDX_PUSH_TEST_COMMAND }}"
             else
-              export CACHE_PUSH_COMMAND="docker push ${{ steps.env2.outputs.CACHE_IMAGE_TAG }}"
+              export CACHE_PUSH_COMMAND="docker push ${{ steps.env2.outputs.CACHE_IMAGE_ID_TAG }}"
             fi
           fi
           ./.github/reusable_workflow/scripts/push_images.sh
@@ -420,7 +420,7 @@ jobs:
            -e IMAGE_TAG=${{ steps.env1.outputs.IMAGE_TAG }} \
            -e ENVIRONMENTS="${{ inputs.production_environments }}" \
            -e ECR_REPOSITORY="${{ inputs.ecr_repository }}" \
-           ${{ steps.env2.outputs.PUBLISH_APP_IMAGE_TAG }}
+           ${{ steps.env2.outputs.PUBLISH_APP_IMAGE_ID_TAG }}
 
       - name: Update GitOps Repo to trigger deploys for test
         if: |
@@ -434,7 +434,7 @@ jobs:
            -e IMAGE_TAG=${{ steps.env1.outputs.IMAGE_TAG }} \
            -e ENVIRONMENTS="${{ inputs.test_environments }}" \
            -e ECR_REPOSITORY="${{ inputs.ecr_repository }}" \
-           ${{ steps.env2.outputs.PUBLISH_APP_IMAGE_TAG }}
+           ${{ steps.env2.outputs.PUBLISH_APP_IMAGE_ID_TAG }}
 
       - name: Update GitOps Repo to trigger deploys for development
         if: |
@@ -447,7 +447,7 @@ jobs:
            -e IMAGE_TAG=${{ steps.env1.outputs.IMAGE_TAG }} \
            -e ENVIRONMENTS="${{ inputs.development_environments }}" \
            -e ECR_REPOSITORY="${{ inputs.ecr_repository }}" \
-           ${{ steps.env2.outputs.PUBLISH_APP_IMAGE_TAG }}
+           ${{ steps.env2.outputs.PUBLISH_APP_IMAGE_ID_TAG }}
 
       - name: check for failures
         id: failure-check

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -115,6 +115,9 @@ jobs:
         ports:
           - "3306:3306"
     steps:
+      - name: Delete huge unnecessary tools folder
+        run: rm -rf /opt/hostedtoolcache
+
       - uses: xt0rted/pull-request-comment-branch@d97294d304604fa98a2600a6e2f916a84b596dc7 # v2.0.0
         if: inputs.event_name == 'issue_comment'
         id: comment-branch

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -349,22 +349,22 @@ jobs:
           NUMBER: 6
         run: cat task_${NUMBER}.txt || (cat task_${NUMBER}_error.txt && exit 1)
 
-      # - name: Image lint results
-      #   id: image-lint
-      #   if: inputs.event_name != 'issue_comment' && always()
-      #   run: cat image_lint.txt || (cat image_lint_error.txt && exit 1)
+      - name: Image lint results
+        id: image-lint
+        if: inputs.event_name != 'issue_comment' && always()
+        run: cat image_lint.txt || (cat image_lint_error.txt && exit 1)
 
-      # - name: Run Image scan on production image for cves
-      #   if: inputs.event_name != 'issue_comment'
-      #   run: |
-      #     image_sha="$(docker images --no-trunc --quiet ${{ steps.env2.outputs.PRODUCTION_IMAGE_TAG }})"
-      #     ${{ steps.build-production.outputs.IMAGE_SCANNER_COMMON }} \
-      #       ./scripts/scan \
-      #       ${{ steps.env2.outputs.PRODUCTION_IMAGE_TAG }} \
-      #       $image_sha \
-      #       /app/Dockerfile \
-      #       ${{ secrets.SNYK_TOKEN }} \
-      #       ${{ inputs.supress_task_failures }}
+      - name: Run Image scan on production image for cves
+        if: inputs.event_name != 'issue_comment'
+        run: |
+          image_sha="$(docker images --no-trunc --quiet ${{ steps.env2.outputs.PRODUCTION_IMAGE_TAG }})"
+          ${{ steps.build-production.outputs.IMAGE_SCANNER_COMMON }} \
+            ./scripts/scan \
+            ${{ steps.env2.outputs.PRODUCTION_IMAGE_TAG }} \
+            $image_sha \
+            /app/Dockerfile \
+            ${{ secrets.SNYK_TOKEN }} \
+            ${{ inputs.supress_task_failures }}
 
       - name: Push to ECR
         run: |

--- a/scripts/additional_tasks.sh
+++ b/scripts/additional_tasks.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 source ./.github/reusable_workflow/scripts/functions.sh
 
-
 export DOCKER_BUILDKIT=1
 async "$BUILD_PRODUCTION_COMMAND" "build" success error
+async "$EXTRA_TASK_IMAGE_LINT_COMMAND" "image_lint" success error
 for ((i=1; i<=EXTRA_TASK_INC; i++)); do
     EXTRA_TASK="EXTRA_TASK_$i"
     [ "${!EXTRA_TASK}" != "" ] && async "${!EXTRA_TASK}" "task_$i" success error

--- a/scripts/additional_tasks.sh
+++ b/scripts/additional_tasks.sh
@@ -3,7 +3,7 @@ source ./.github/reusable_workflow/scripts/functions.sh
 
 export DOCKER_BUILDKIT=1
 async "$BUILD_PRODUCTION_COMMAND" "build" success error
-# async "$EXTRA_TASK_IMAGE_LINT_COMMAND" "image_lint" success error
+async "$EXTRA_TASK_IMAGE_LINT_COMMAND" "image_lint" success error
 for ((i=1; i<=EXTRA_TASK_INC; i++)); do
     EXTRA_TASK="EXTRA_TASK_$i"
     [ "${!EXTRA_TASK}" != "" ] && async "${!EXTRA_TASK}" "task_$i" success error

--- a/scripts/additional_tasks.sh
+++ b/scripts/additional_tasks.sh
@@ -3,7 +3,7 @@ source ./.github/reusable_workflow/scripts/functions.sh
 
 export DOCKER_BUILDKIT=1
 async "$BUILD_PRODUCTION_COMMAND" "build" success error
-async "$EXTRA_TASK_IMAGE_LINT_COMMAND" "image_lint" success error
+# async "$EXTRA_TASK_IMAGE_LINT_COMMAND" "image_lint" success error
 for ((i=1; i<=EXTRA_TASK_INC; i++)); do
     EXTRA_TASK="EXTRA_TASK_$i"
     [ "${!EXTRA_TASK}" != "" ] && async "${!EXTRA_TASK}" "task_$i" success error

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -32,7 +32,7 @@ async() {
     resolve="$3"
     reject="$4"
     {
-        echo "`date "+%Y-%m-%d %H:%M:%S"` Running $command"
+        echo "`date "+%Y-%m-%d %H:%M:%S"` Running $log_name ($command)"
         ## this just starts the timers
         _x=$SECONDS
         $command > temp_${JOBS}.txt 2>&1
@@ -46,7 +46,7 @@ async() {
             $reject "${__result}" "${log_name}" "${status}" "${JOBS}"
         }
         unset __result
-        echo "`date "+%Y-%m-%d %H:%M:%S"` Finished $command Took $SECONDS"
+        echo "`date "+%Y-%m-%d %H:%M:%S"` Finished $log_name Took $SECONDS"
     } &
 
     JOB_IDS+=( "${JOBS} ${command}" )

--- a/scripts/functions.sh
+++ b/scripts/functions.sh
@@ -46,7 +46,7 @@ async() {
             $reject "${__result}" "${log_name}" "${status}" "${JOBS}"
         }
         unset __result
-        echo "`date "+%Y-%m-%d %H:%M:%S"` Finished $log_name Took $SECONDS"
+        echo "`date "+%Y-%m-%d %H:%M:%S"` Finished $log_name (Code: $status) Took $SECONDS"
     } &
 
     JOB_IDS+=( "${JOBS} ${command}" )


### PR DESCRIPTION
* Adds logic to support a new input of override_image_tag -> when provided this overwrites the magic `stable-SHA` will be used for generic docker builds that dont need such a hard version lock.
* adds logic to run the image linting during build of prod and extras tasks
* adds logic to scan for cves on prod image. this currently is only happening in master merges.

closes https://github.com/ausaccessfed/aaf-terraform/issues/1509