### PR TITLE
Lint the prod image not cache image

### DIFF
--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -406,7 +406,8 @@ jobs:
         run: |
           ${{ steps.build-production.outputs.IMAGE_SCANNER_COMMON }} \
             ./scripts/lint \
-            ${{ steps.env2.outputs.PRODUCTION_IMAGE_ID_TAG }}
+            ${{ steps.env2.outputs.PRODUCTION_IMAGE_ID_TAG }} \
+            /app/Dockerfile
 
       # TODO: master/main branch merges only for now
       - name: Run Image scan on production image for cves

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -308,8 +308,6 @@ jobs:
           IMAGE_SCANNER_COMMON="docker run -u 0 -v /var/run/docker.sock:/var/run/docker.sock ${IMAGE_SCANNER_EXTRAS} ${{ steps.env2.outputs.IMAGE_SCANNER_IMAGE_ID_TAG }}"
           echo "IMAGE_SCANNER_COMMON=$IMAGE_SCANNER_COMMON" >> $GITHUB_OUTPUT
 
-          export EXTRA_TASK_IMAGE_LINT_COMMAND="$IMAGE_SCANNER_COMMON ./scripts/lint ${{ steps.env2.outputs.LOCAL_CACHE_IMAGE_ID_TAG }} /app/Dockerfile"
-
           ./.github/reusable_workflow/scripts/additional_tasks.sh
 
       - name: Load Production OCI Image
@@ -402,6 +400,13 @@ jobs:
             cat image_lint_error.txt
             exit 1
           fi
+
+      - name: Run Image lint on production image
+        if: steps.env1.outputs.IS_SLASH_DEPLOY == 'false'
+        run: |
+          ${{ steps.build-production.outputs.IMAGE_SCANNER_COMMON }} \
+            ./scripts/lint \
+            ${{ steps.env2.outputs.PRODUCTION_IMAGE_ID_TAG }}
 
       # TODO: master/main branch merges only for now
       - name: Run Image scan on production image for cves

--- a/scripts/additional_tasks.sh
+++ b/scripts/additional_tasks.sh
@@ -3,7 +3,6 @@ source ./.github/reusable_workflow/scripts/functions.sh
 
 export DOCKER_BUILDKIT=1
 async "$BUILD_PRODUCTION_COMMAND" "build" success error
-async "$EXTRA_TASK_IMAGE_LINT_COMMAND" "image_lint" success error
 for ((i=1; i<=EXTRA_TASK_INC; i++)); do
     EXTRA_TASK="EXTRA_TASK_$i"
     [ "${!EXTRA_TASK}" != "" ] && async "${!EXTRA_TASK}" "task_$i" success error


### PR DESCRIPTION
Oversight i didnt notice we were linting cache thinking it didnt make much difference.

But ofcourse dockle will warn us that the cache image isnt safe. we don't care  about that fact, we just care about the final image we distribute

Instead just do it after prod is built and 