### PR TITLE
Have 1 commit per pr instead to reduce noise

### DIFF
--- a/.github/workflows/workflow-distributor.yml
+++ b/.github/workflows/workflow-distributor.yml
@@ -2,8 +2,8 @@ name: 'Distribute Workflows'
 on:
   workflow_dispatch:
   push:
-    branches:
-      - main
+    # branches:
+    #   - main
 jobs:
   distribution:
     runs-on: ubuntu-latest
@@ -11,7 +11,8 @@ jobs:
       contents: read
     strategy:
       matrix:
-        repository: ${{ fromJSON(vars.RENOVATE_REPOSITORIES) }}
+        # repository: ${{ fromJSON(vars.RENOVATE_REPOSITORIES) }}
+        repository: ${{ fromJSON('["ausaccessfed/reporting-service"]') }}
     steps:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0

--- a/.github/workflows/workflow-distributor.yml
+++ b/.github/workflows/workflow-distributor.yml
@@ -2,8 +2,8 @@ name: 'Distribute Workflows'
 on:
   workflow_dispatch:
   push:
-    # branches:
-    #   - main
+    branches:
+      - main
 jobs:
   distribution:
     runs-on: ubuntu-latest
@@ -11,8 +11,7 @@ jobs:
       contents: read
     strategy:
       matrix:
-        # repository: ${{ fromJSON(vars.RENOVATE_REPOSITORIES) }}
-        repository: ${{ fromJSON('["ausaccessfed/reporting-service"]') }}
+        repository: ${{ fromJSON(vars.RENOVATE_REPOSITORIES) }}
     steps:
       - name: Checkout
         uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3.6.0

--- a/scripts/workflow-distributor.js
+++ b/scripts/workflow-distributor.js
@@ -67,7 +67,6 @@ const getFile = async ({ repo, path, ref }) => {
 }
 
 const createCommit = async ({ repo, baseSha, tree, message }) => {
-  console.dir(tree)
   const {
     data: { sha: treeSha }
   } = await GLOBALS.github.rest.git.createTree({

--- a/scripts/workflow-distributor.js
+++ b/scripts/workflow-distributor.js
@@ -240,7 +240,7 @@ const createPR = async ({ repo, tree, baseBranch }) => {
   } = await getBranch({ repo, branch: baseBranch })
 
   const message = ''
-  const { newCommitSha, isDiff } = await createCommit({ repo, tree, baseSha, message })
+  const { newCommitSha, isDiff } = await createCommit({ repo, tree: tree.filter((x) => x), baseSha, message })
 
   if (isDiff) {
     await GLOBALS.github.rest.git.createRef({

--- a/scripts/workflow-distributor.js
+++ b/scripts/workflow-distributor.js
@@ -222,11 +222,6 @@ const getFileRemovals = async ({ repo, parsedFiles, baseBranch }) => {
   return filesToBeRemoved
 }
 
-const updateCacheFileTreeObject = async ({ baseBranch, repo, parsedFile, parsedFiles }) => {
-  parsedFile.newContent = parsedFiles.map((file) => file.distributionsFilePath).join('\n')
-  return await updateFileTreeObject({ baseBranch, repo, parsedFile })
-}
-
 const getFiles = async () => {
   const globber = await GLOBALS.glob.create('**/**/distributions/**/**.*', { followSymbolicLinks: false })
   return await globber.glob()
@@ -239,7 +234,7 @@ const createPR = async ({ repo, tree, baseBranch }) => {
     }
   } = await getBranch({ repo, branch: baseBranch })
 
-  const message = ''
+  const message = 'Updating distribution files'
   const { newCommitSha, isDiff } = await createCommit({ repo, tree: tree.filter((x) => x), baseSha, message })
 
   if (isDiff) {

--- a/scripts/workflow-distributor.js
+++ b/scripts/workflow-distributor.js
@@ -67,6 +67,7 @@ const getFile = async ({ repo, path, ref }) => {
 }
 
 const createCommit = async ({ repo, baseSha, tree, message }) => {
+  console.dir(tree)
   const {
     data: { sha: treeSha }
   } = await GLOBALS.github.rest.git.createTree({


### PR DESCRIPTION
https://github.com/ausaccessfed/reporting-service/pull/422

Refactored to instead loop all files and prepare tree then just create a ref

reduces the api calls by a bunch and simplifies the code