### PR TITLE
Add missing `/` for `BASE_IMAGE` var

### DIFF
--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -208,7 +208,7 @@ jobs:
           echo "IMAGE_SCANNER_IMAGE_ID_TAG=$ECR_REGISTRY/image-scanner:latest" >> $GITHUB_OUTPUT
 
           VERSION=$(${{ inputs.version_command }})
-          BASE_IMAGE="${{ secrets.DOCKER_ECR }}ruby-base:${VERSION}"
+          BASE_IMAGE="${{ secrets.DOCKER_ECR }}/ruby-base:${VERSION}"
           echo "BASE_IMAGE=$BASE_IMAGE" >> $GITHUB_OUTPUT
 
           # Strip git ref prefix from version


### PR DESCRIPTION
Maybe, see https://ausaccessfed.slack.com/archives/G010TGS7ERY/p1701992825338289?thread_ts=1701986361.956539&cid=G010TGS7ERY 

The `DOCKER_ECR` no longer includes the `/` so needs to be added manually. 