### PR TITLE
Fix actor check

### DIFF
--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -101,7 +101,7 @@ jobs:
   run:
     runs-on: ${{ inputs.runner }}
     name: run
-    if: inputs.event_name != 'issue_comment' || (contains(inputs.event_comment_body, '/deploy')  && contains('phyzical,ArthurZheng,ritchiey,matthew-puku,rianniello,Kfoster14,waldofouche,Bo', github.event.author.login))
+    if: inputs.event_name != 'issue_comment' || (contains(inputs.event_comment_body, '/deploy')  && contains(fromJSON(vars.ALLOWED_ACTORS), github.event.author.login))
     services:
       mysql:
         image: mysql:5.7


### PR DESCRIPTION
adjust actor check to avoid partial matches to be explicit matches

this was one of the issues raised by the security audit, the current logic just allowed for partial matches i.e `phyzicaly` would be matched

now its an array and will be explicitly matches