### PR TITLE
use the reposcope token to allow follow on workflows

### DIFF
--- a/.github/workflows/distributions/.github/workflows/pr-housekeeping.yml
+++ b/.github/workflows/distributions/.github/workflows/pr-housekeeping.yml
@@ -10,5 +10,5 @@ jobs:
       issues: write
       pull-requests: write
     secrets:
-      REPO_SCOPED_TOKEN: ${{secrets.GITHUB_TOKEN}}
+      REPO_SCOPED_TOKEN: ${{secrets.REPO_SCOPED_TOKEN}}
     uses: ausaccessfed/workflows/.github/workflows/pr-housekeeping.yml@main


### PR DESCRIPTION
https://github.com/ausaccessfed/aaf-terraform/issues/2596

switches over to a PAT from a github token to avoid the limitation around workflows creating additional workflow events