### PR TITLE
Yolo-merge docker dependency updates

### DIFF
--- a/.github/workflows/pr-housekeeping.yml
+++ b/.github/workflows/pr-housekeeping.yml
@@ -4,7 +4,7 @@ on:
     inputs:
       AUTO_MERGEABLE_LABELS:
         type: string
-        default: 'development,test,devDependencies,testDependencies'
+        default: 'development,test,devDependencies,testDependencies,dockerDependencies'
     secrets:
       REPO_SCOPED_TOKEN:
         required: true


### PR DESCRIPTION
Version-pinned docker dependencies tend to break the build very very often. This gums up the rest of the renovate PRs and spends a lot of developer time.

I've never seen one of these build successfully and then break something, so I think it is safe enough to send these to the test federation if the build passes. Might need to revisit if we're ever considering deploying straight to production. 🤷