### PR TITLE
resolves role-session-name is limited to 64 characters error 

### DIFF
--- a/.github/workflows/sync-development.yml
+++ b/.github/workflows/sync-development.yml
@@ -31,7 +31,7 @@ jobs:
         with:
           aws-region: ap-southeast-2
           role-to-assume: ${{ secrets.ROLE }}
-          role-session-name: GithubActions-${{ inputs.app }}-ci
+          role-session-name: GithubActions-${{ inputs.ecr_repository }}-ci
 
       - name: Login to Amazon ECR
         id: login-ecr


### PR DESCRIPTION
https://github.com/ausaccessfed/puppeteer-tester/actions/runs/9249872473/job/25442396736

role-session-name is limited to 64 characters. this uses the repository name instead