### PR TITLE
Use the branch ref not sha

### DIFF
--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -144,10 +144,13 @@ jobs:
           IS_DEFAULT_DEVELOPMENT_BRANCH_PUSH=$(([ "${{ inputs.event_name }}" == "push" ] && [ "${{steps.branch.outputs.BRANCH_NAME}}" == "${{ inputs.default_develop_branch }}" ]) && echo "true" || echo "false")
           echo "IS_DEFAULT_DEVELOPMENT_BRANCH_PUSH=$IS_DEFAULT_DEVELOPMENT_BRANCH_PUSH" >> $GITHUB_OUTPUT
 
+          BRANCH_IMAGE_TAG=adhoc-${{steps.comment-branch.outputs.head_ref}}-${{steps.comment-branch.outputs.HEAD_SHA}}
+          SHA_IMAGE_TAG=stable-${{ github.sha }}
+
           if [ "$IS_SLASH_DEPLOY" == "true" ]; then
-            IMAGE_TAG=adhoc-${{steps.comment-branch.outputs.head_ref}}-${{steps.comment-branch.outputs.HEAD_SHA}}
+            IMAGE_TAG="$BRANCH_IMAGE_TAG"
           else
-            IMAGE_TAG=stable-${{ github.sha }}
+            IMAGE_TAG="$SHA_IMAGE_TAG"
           fi
           IMAGE_TAG=$(echo "$IMAGE_TAG" | tr / _)
           echo "IMAGE_TAG=$IMAGE_TAG" >> $GITHUB_OUTPUT
@@ -190,7 +193,7 @@ jobs:
           if [ "$IS_DEFAULT_BRANCH_PUSH" == "true" ]; then
             echo "GITHUB_BRANCH_CACHE_IMAGE_ID_TAG=$GITHUB_CACHE_IMAGE_ID_TAG" >> $GITHUB_OUTPUT
           else
-            echo "GITHUB_BRANCH_CACHE_IMAGE_ID_TAG=$GITHUB_REGISTRY_REF:cache-$IMAGE_TAG" >> $GITHUB_OUTPUT
+            echo "GITHUB_BRANCH_CACHE_IMAGE_ID_TAG=$GITHUB_REGISTRY_REF:cache-$BRANCH_IMAGE_TAG" >> $GITHUB_OUTPUT
           fi
 
           GITHUB_LATEST_IMAGE_ID_TAG="$GITHUB_REGISTRY_REF:latest"
@@ -199,7 +202,7 @@ jobs:
           if [ "$IS_DEFAULT_BRANCH_PUSH" == "true" ]; then
             echo "GITHUB_BRANCH_LATEST_IMAGE_ID_TAG=$GITHUB_LATEST_IMAGE_ID_TAG" >> $GITHUB_OUTPUT
           else
-            echo "GITHUB_BRANCH_LATEST_IMAGE_ID_TAG=$GITHUB_REGISTRY_REF:latest-$IMAGE_TAG" >> $GITHUB_OUTPUT
+            echo "GITHUB_BRANCH_LATEST_IMAGE_ID_TAG=$GITHUB_REGISTRY_REF:latest-$BRANCH_IMAGE_TAG" >> $GITHUB_OUTPUT
           fi
 
           PROJECTS="${{ inputs.ecr_repository }}"


### PR DESCRIPTION
This meant that we were creating an image per commit...
use the branch ref instead
resulting in 0 caching oops