### PR TITLE
Allow selection of more expensive runners

### DIFF
--- a/.github/actions/image_scanner/action.yaml
+++ b/.github/actions/image_scanner/action.yaml
@@ -68,7 +68,7 @@ runs:
         docker run \
           -u 0 \
           -v /var/run/docker.sock:/var/run/docker.sock \
-          ${{ steps.args.outputs.IMAGE_SCANNER_EXTRAS} \
+          ${{ steps.args.outputs.IMAGE_SCANNER_EXTRAS }} \
           ghcr.io/ausaccessfed/image-scanner:latest \
           ./scripts/${{ inputs.SCAN_NAME }} \
           ${{ steps.args.outputs.ARGS }}

--- a/.github/actions/image_scanner/action.yaml
+++ b/.github/actions/image_scanner/action.yaml
@@ -1,0 +1,74 @@
+name: 'Image scan'
+description: ''
+inputs:
+  BRANCH_NAME:
+    description: 'branch to checkout'
+    required: true
+  GITHUB_TOKEN:
+    description: 'github token used to auth to ghcr'
+    required: true
+  GITHUB_ACTOR:
+    description: 'github actor used to auth to ghcr'
+    required: true
+  SCAN_NAME:
+    description: 'Which scan to run'
+    required: true
+  IMAGE_TAG_FOR_SCAN:
+    description: 'Tag to run scans on'
+    required: true
+  SNYK_TOKEN:
+    description: 'Only needed when running snyk'
+    default: ''
+runs:
+  using: 'composite'
+  steps:
+    - uses: ausaccessfed/workflows/.github/actions/init@main
+      with:
+        BRANCH_NAME: ${{ inputs.BRANCH_NAME }}
+        GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}
+        GITHUB_ACTOR: ${{ inputs.GITHUB_ACTOR }}
+
+    - name: pull the image
+      shell: bash
+      run: docker pull ${{ inputs.IMAGE_TAG_FOR_SCAN }}
+
+    - name: args
+      id: args
+      shell: bash
+      run: |
+        IMAGE_SCANNER_EXTRAS=""
+
+        if [ -f "${PWD}/Dockerfile" ]; then
+          IMAGE_SCANNER_EXTRAS="-v ${PWD}/Dockerfile:/app/Dockerfile ${IMAGE_SCANNER_EXTRAS}"
+        fi
+
+        if [ -f "${PWD}/.dockleignore" ]; then
+          IMAGE_SCANNER_EXTRAS="-v ${PWD}/.dockleignore:/app/.dockleignore ${IMAGE_SCANNER_EXTRAS}"
+        fi
+
+        if [ -f "${PWD}/.hadolint.yaml" ]; then
+          IMAGE_SCANNER_EXTRAS="-v ${PWD}/.hadolint.yaml:/app/.hadolint.yaml ${IMAGE_SCANNER_EXTRAS}"
+        fi
+        echo "IMAGE_SCANNER_EXTRAS=$IMAGE_SCANNER_EXTRAS" >> $GITHUB_OUTPUT
+
+        ARGS="${{ inputs.IMAGE_TAG_FOR_SCAN }}"
+        if [ "${{ inputs.SCAN_NAME }}" = "snyk" ]; then
+          ARGS="${{ inputs.IMAGE_TAG_FOR_SCAN }} /app/Dockerfile ${{ inputs.SNYK_TOKEN }}"
+        fi
+        if [ "${{ inputs.SCAN_NAME }}" = "hadolint" ]; then
+          ARGS="/app/Dockerfile"
+        fi
+        echo "ARGS=$ARGS" >> $GITHUB_OUTPUT
+
+    - name: Run image scanner
+      shell: bash
+      env:
+        DOCKLE_HOST: 'unix:///var/run/docker.sock'
+      run: |
+        docker run \
+          -u 0 \
+          -v /var/run/docker.sock:/var/run/docker.sock \
+          ${{ steps.args.outputs.IMAGE_SCANNER_EXTRAS} \
+          ghcr.io/ausaccessfed/image-scanner:latest \
+          ./scripts/${{ inputs.SCAN_NAME }} \
+          ${{ steps.args.outputs.ARGS }}

--- a/.github/actions/image_scanner/action.yaml
+++ b/.github/actions/image_scanner/action.yaml
@@ -19,6 +19,9 @@ inputs:
   SNYK_TOKEN:
     description: 'Only needed when running snyk'
     default: ''
+  SUPPRESS_FAILURE:
+    description: 'Set to true to suppress any failures'
+    default: 'false'
 runs:
   using: 'composite'
   steps:
@@ -71,4 +74,4 @@ runs:
           ${{ steps.args.outputs.IMAGE_SCANNER_EXTRAS }} \
           ghcr.io/ausaccessfed/image-scanner:latest \
           ./scripts/${{ inputs.SCAN_NAME }} \
-          ${{ steps.args.outputs.ARGS }}
+          ${{ steps.args.outputs.ARGS }} || [ "${{ inputs.SUPPRESS_FAILURE }}" = "true" ] && echo "Failed, but marked as skippable"

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -451,7 +451,7 @@ jobs:
           GITHUB_ACTOR: ${{ github.actor }}
           IMAGE_TAG_FOR_SCAN: ${{ needs.init.outputs.GITHUB_BRANCH_LATEST_IMAGE_ID_TAG }}
           SCAN_NAME: trivy
-          SUPPRESS_FAILURE: false
+          SUPPRESS_FAILURE: true
 
   push-to-ecr:
     needs: [init, commands, trivy-cve-scan, grype-cve-scan, snyk-cve-scan, hadolint, dockle-lint]

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -332,7 +332,7 @@ jobs:
       matrix:
         arch: ${{ (inputs.commands != '["skip"]' && needs.init.outputs.IS_SLASH_DEPLOY == 'false' &&  fromJSON(inputs.platforms)) || fromJSON('["linux/amd64"]') }}
         command: ${{ fromJSON(inputs.commands) }}
-    runs-on: ${{ (matrix.arch == 'linux/amd64' && needs.init.outputs.INTEL_RUNNER) || needs.init.outputs.ARM_RUNNER }}
+    runs-on: ${{ (matrix.arch == 'linux/amd64' && ((contains(matrix.command, 'MORE_POWER') && needs.init.outputs.INTEL_RUNNER) || needs.init.outputs.INTEL_RUNNER_CHEAP)) || ((contains(matrix.command, 'MORE_POWER') && needs.init.outputs.ARM_RUNNER) || needs.init.outputs.ARM_RUNNER_CHEAP) }}
     name: ${{ format(matrix.command, '') }} (${{ matrix.arch }})
     services:
       mysql:

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -91,7 +91,6 @@ jobs:
       PRODUCTION_IMAGE_ID_TAG: ${{ steps.env.outputs.PRODUCTION_IMAGE_ID_TAG }}
       LATEST_IMAGE_ID_TAG: ${{ steps.env.outputs.LATEST_IMAGE_ID_TAG }}
       SHOULD_PUSH_IMAGE_TO_ECR: ${{ steps.env.outputs.SHOULD_PUSH_IMAGE_TO_ECR }}
-      IMAGE_SCANNER_COMMON: ${{ steps.env.outputs.IMAGE_SCANNER_COMMON }}
       GITHUB_REGISTRY_REF: ${{ steps.env.outputs.GITHUB_REGISTRY_REF }}
       GITHUB_TEST_IMAGE_ID_TAG: ${{ steps.env.outputs.GITHUB_TEST_IMAGE_ID_TAG }}
       GITHUB_LATEST_IMAGE_ID_TAG: ${{ steps.env.outputs.GITHUB_LATEST_IMAGE_ID_TAG }}
@@ -228,21 +227,6 @@ jobs:
             PROJECTS="${{ inputs.projects }}"
           fi
           echo "PROJECTS=$PROJECTS" >> $GITHUB_OUTPUT
-
-          IMAGE_SCANNER_EXTRAS=""
-          if [ -f "${PWD}/Dockerfile" ]; then
-            IMAGE_SCANNER_EXTRAS="-v ${PWD}/Dockerfile:/app/Dockerfile ${IMAGE_SCANNER_EXTRAS}"
-          fi
-          if [ -f "${PWD}/.dockleignore" ]; then
-            IMAGE_SCANNER_EXTRAS="-v ${PWD}/.dockleignore:/app/.dockleignore ${IMAGE_SCANNER_EXTRAS}"
-          fi
-          if [ -f "${PWD}/.hadolint.yaml" ]; then
-            IMAGE_SCANNER_EXTRAS="-v ${PWD}/.hadolint.yaml:/app/.hadolint.yaml ${IMAGE_SCANNER_EXTRAS}"
-          fi
-          IMAGE_SCANNER_IMAGE_ID_TAG="$GITHUB_REGISTRY_ROOT_REF/image-scanner:latest"
-
-          IMAGE_SCANNER_COMMON="docker run -u 0 -v /var/run/docker.sock:/var/run/docker.sock ${IMAGE_SCANNER_EXTRAS} $IMAGE_SCANNER_IMAGE_ID_TAG"
-          echo "IMAGE_SCANNER_COMMON=$IMAGE_SCANNER_COMMON" >> $GITHUB_OUTPUT
 
           # Note this assumes runners exist given the naming ARCH-NUM_CORES-cores
           # TODO: make this work for more than intel and arm? maybe we dont need anything else
@@ -391,30 +375,15 @@ jobs:
     runs-on: ${{ (matrix.arch == 'linux/amd64' && needs.init.outputs.INTEL_RUNNER) || needs.init.outputs.ARM_RUNNER }}
     env:
       DOCKLE_HOST: 'unix:///var/run/docker.sock'
-    name: Running Image lint on ${{ matrix.arch }}
+    name: Running Dockle lint
     steps:
-      - uses: ausaccessfed/workflows/.github/actions/init@main
+      - uses: ausaccessfed/workflows/.github/actions/image_scanner@feature/more-build-adjustments
         with:
           BRANCH_NAME: ${{ needs.init.outputs.BRANCH_NAME }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}
-
-      - name: Run
-        id: run
-        run: |
-          docker pull ${{ needs.init.outputs.GITHUB_BRANCH_LATEST_IMAGE_ID_TAG }}
-          ${{needs.init.outputs.IMAGE_SCANNER_COMMON}} \
-            dockle \
-            -i CIS-DI-0005 \
-            -i CIS-DI-0006 \
-            -i DKL-DI-0006 \
-            -af carrierwave.rb \
-            -af database.yml \
-            -af omniauth.rb \
-            --exit-code 1 \
-            --exit-level \
-            info \
-            "${{ needs.init.outputs.GITHUB_BRANCH_LATEST_IMAGE_ID_TAG }}"
+          IMAGE_TAG_FOR_SCAN: ${{ needs.init.outputs.GITHUB_BRANCH_LATEST_IMAGE_ID_TAG }}
+          SCAN_NAME: dockle
 
   hadolint:
     needs: [init, post-build-production]
@@ -422,54 +391,71 @@ jobs:
       matrix:
         arch: ${{ fromJSON(inputs.platforms) }}
     runs-on: ${{ (matrix.arch == 'linux/amd64' && needs.init.outputs.INTEL_RUNNER) || needs.init.outputs.ARM_RUNNER }}
-    env:
-      DOCKLE_HOST: 'unix:///var/run/docker.sock'
-    name: Running Image lint on ${{ matrix.arch }}
+    name: Running Hadolint
     steps:
-      - uses: ausaccessfed/workflows/.github/actions/init@main
+      - uses: ausaccessfed/workflows/.github/actions/image_scanner@feature/more-build-adjustments
         with:
           BRANCH_NAME: ${{ needs.init.outputs.BRANCH_NAME }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}
+          IMAGE_TAG_FOR_SCAN: ${{ needs.init.outputs.GITHUB_BRANCH_LATEST_IMAGE_ID_TAG }}
+          SCAN_NAME: hadolint
 
-      - name: Run
-        id: run
-        run: |
-          docker pull ${{ needs.init.outputs.GITHUB_BRANCH_LATEST_IMAGE_ID_TAG }}
-          ${{needs.init.outputs.IMAGE_SCANNER_COMMON}} \
-            hadolint \
-            --config /app/.hadolint.yaml \
-            --failure-threshold style \
-            "/app/Dockerfile"
-
-  image-scan:
+  snyk-cve-scan:
     needs: [init, post-build-production]
-    # continue-on-error: true
+    continue-on-error: true
     strategy:
       matrix:
         arch: ${{ fromJSON(inputs.platforms) }}
     runs-on: ${{ (matrix.arch == 'linux/amd64' && needs.init.outputs.INTEL_RUNNER) || needs.init.outputs.ARM_RUNNER }}
-    name: Running Image scan on ${{ matrix.arch }}
+    name: Running Snyk cve scan
     steps:
-      - uses: ausaccessfed/workflows/.github/actions/init@main
+      - uses: ausaccessfed/workflows/.github/actions/image_scanner@feature/more-build-adjustments
         with:
           BRANCH_NAME: ${{ needs.init.outputs.BRANCH_NAME }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}
+          IMAGE_TAG_FOR_SCAN: ${{ needs.init.outputs.GITHUB_BRANCH_LATEST_IMAGE_ID_TAG }}
+          SCAN_NAME: snyk
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
 
-      # - name: Run Image scan on production image for cves
-      #   run: |
-      #     docker pull ${{ needs.init.outputs.GITHUB_BRANCH_LATEST_IMAGE_ID_TAG }}
-      #     ${{ needs.init.outputs.IMAGE_SCANNER_COMMON }} \
-      #       ./scripts/scan \
-      #       ${{ needs.init.outputs.GITHUB_BRANCH_LATEST_IMAGE_ID_TAG }} \
-      #       $IMAGE_SHA \
-      #       /app/Dockerfile \
-      #       ${{ secrets.SNYK_TOKEN }} \
-      #       true
+  grype-cve-scan:
+    needs: [init, post-build-production]
+    continue-on-error: true
+    strategy:
+      matrix:
+        arch: ${{ fromJSON(inputs.platforms) }}
+    runs-on: ${{ (matrix.arch == 'linux/amd64' && needs.init.outputs.INTEL_RUNNER) || needs.init.outputs.ARM_RUNNER }}
+    name: Running Grype cve scan
+    steps:
+      - uses: ausaccessfed/workflows/.github/actions/image_scanner@feature/more-build-adjustments
+        with:
+          BRANCH_NAME: ${{ needs.init.outputs.BRANCH_NAME }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.actor }}
+          IMAGE_TAG_FOR_SCAN: ${{ needs.init.outputs.GITHUB_BRANCH_LATEST_IMAGE_ID_TAG }}
+          SCAN_NAME: grype
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+
+  trivy-cve-scan:
+    needs: [init, post-build-production]
+    continue-on-error: true
+    strategy:
+      matrix:
+        arch: ${{ fromJSON(inputs.platforms) }}
+    runs-on: ${{ (matrix.arch == 'linux/amd64' && needs.init.outputs.INTEL_RUNNER) || needs.init.outputs.ARM_RUNNER }}
+    name: Running Trivy cve scan
+    steps:
+      - uses: ausaccessfed/workflows/.github/actions/image_scanner@feature/more-build-adjustments
+        with:
+          BRANCH_NAME: ${{ needs.init.outputs.BRANCH_NAME }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.actor }}
+          IMAGE_TAG_FOR_SCAN: ${{ needs.init.outputs.GITHUB_BRANCH_LATEST_IMAGE_ID_TAG }}
+          SCAN_NAME: trivy
 
   push-to-ecr:
-    needs: [init, commands, image-scan, hadolint, dockle-lint]
+    needs: [init, commands, trivy-cve-scan, grype-cve-scan, snyk-cve-scan, hadolint, dockle-lint]
     if: needs.init.outputs.SHOULD_PUSH_IMAGE_TO_ECR == 'true'
     strategy:
       matrix:
@@ -575,7 +561,9 @@ jobs:
         commands,
         hadolint,
         dockle-lint,
-        image-scan,
+        trivy-cve-scan,
+        grype-cve-scan,
+        snyk-cve-scan,
         push-to-ecr,
         update-production-manifests,
         update-terraform-manifests
@@ -640,7 +628,9 @@ jobs:
         commands,
         hadolint,
         dockle-lint,
-        image-scan,
+        trivy-cve-scan,
+        grype-cve-scan,
+        snyk-cve-scan,
         push-to-ecr,
         update-production-manifests,
         update-terraform-manifests
@@ -651,7 +641,7 @@ jobs:
     steps:
       - name: check for failures
         run: |
-          STRING="${{ needs.init.result }}${{ needs.build-test.result }}${{ needs.build-production.result }}${{ needs.commands.result }}${{ needs.hadolint.result }}${{ needs.dockle-lint.result }}${{ needs.image-scan.result }}${{ needs.push-to-ecr.result }}${{ needs.update-production-manifests.result }}${{ needs.update-terraform-manifests.result }}"
+          STRING="${{ needs.init.result }}${{ needs.build-test.result }}${{ needs.build-production.result }}${{ needs.commands.result }}${{ needs.hadolint.result }}${{ needs.dockle-lint.result }}${{ needs.trivy-cve-scan.result }}${{ needs.grype-cve-scan.result }}${{ needs.snyk-cve-scan.result }}${{ needs.push-to-ecr.result }}${{ needs.update-production-manifests.result }}${{ needs.update-terraform-manifests.result }}"
           if [ "$(echo "$STRING" | grep "failure" || echo "")" != "" ]; then
             exit 1
           fi

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -339,11 +339,10 @@ jobs:
 
   commands:
     needs: [init, post-build-test]
-    if: inputs.commands != 'skip'
     strategy:
       fail-fast: false
       matrix:
-        arch: ${{ fromJSON(inputs.platforms) }}
+        arch: ${{ (inputs.commands == '["skip"]' && fromJSON('["linux/amd64"]')) || fromJSON(inputs.platforms) }}
         command: ${{ fromJSON(inputs.commands) }}
     runs-on: ${{ (matrix.arch == 'linux/amd64' && needs.init.outputs.INTEL_RUNNER) || needs.init.outputs.ARM_RUNNER }}
     name: ${{ format(matrix.command, '') }} (${{ matrix.arch }})
@@ -355,6 +354,7 @@ jobs:
         ports:
           - '3306:3306'
     steps:
+      # TODO: make sure this whole step doesnt count as a skip
       - uses: ausaccessfed/workflows/.github/actions/init@main
         if: inputs.commands != '["skip"]'
         with:
@@ -382,7 +382,8 @@ jobs:
     #   with:
     #     name: failed_images
     #     path: screenshots.zip
-  image-lint:
+
+  dockle-lint:
     needs: [init, post-build-production]
     strategy:
       matrix:
@@ -403,13 +404,47 @@ jobs:
         run: |
           docker pull ${{ needs.init.outputs.GITHUB_BRANCH_LATEST_IMAGE_ID_TAG }}
           ${{needs.init.outputs.IMAGE_SCANNER_COMMON}} \
-            ./scripts/lint \
-            ${{ needs.init.outputs.GITHUB_BRANCH_LATEST_IMAGE_ID_TAG }} \
-            /app/Dockerfile
+            dockle \
+            -i CIS-DI-0005 \
+            -i CIS-DI-0006 \
+            -i DKL-DI-0006 \
+            -af carrierwave.rb \
+            -af database.yml \
+            -af omniauth.rb \
+            --exit-code 1 \
+            --exit-level \
+            info \
+            "${{ needs.init.outputs.GITHUB_BRANCH_LATEST_IMAGE_ID_TAG }}"
 
-  # TODO: should we async the inside jobs instead of bash async within the image?
+  hadolint:
+    needs: [init, post-build-production]
+    strategy:
+      matrix:
+        arch: ${{ fromJSON(inputs.platforms) }}
+    runs-on: ${{ (matrix.arch == 'linux/amd64' && needs.init.outputs.INTEL_RUNNER) || needs.init.outputs.ARM_RUNNER }}
+    env:
+      DOCKLE_HOST: 'unix:///var/run/docker.sock'
+    name: Running Image lint on ${{ matrix.arch }}
+    steps:
+      - uses: ausaccessfed/workflows/.github/actions/init@main
+        with:
+          BRANCH_NAME: ${{ needs.init.outputs.BRANCH_NAME }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_ACTOR: ${{ github.actor }}
+
+      - name: Run
+        id: run
+        run: |
+          docker pull ${{ needs.init.outputs.GITHUB_BRANCH_LATEST_IMAGE_ID_TAG }}
+          ${{needs.init.outputs.IMAGE_SCANNER_COMMON}} \
+            hadolint \
+            --config /app/.hadolint.yaml \
+            --failure-threshold style \
+            "/app/Dockerfile"
+
   image-scan:
     needs: [init, post-build-production]
+    # continue-on-error: true
     strategy:
       matrix:
         arch: ${{ fromJSON(inputs.platforms) }}

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -326,7 +326,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: ${{ (inputs.commands == '["skip"]' && fromJSON('["linux/amd64"]')) || fromJSON(inputs.platforms) }}
+        arch: ${{ (inputs.commands != '["skip"]' && needs.init.outputs.IS_SLASH_DEPLOY == 'false' &&  fromJSON(inputs.platforms)) || fromJSON('["linux/amd64"]') }}
         command: ${{ fromJSON(inputs.commands) }}
     runs-on: ${{ (matrix.arch == 'linux/amd64' && needs.init.outputs.INTEL_RUNNER) || needs.init.outputs.ARM_RUNNER }}
     name: ${{ format(matrix.command, '') }} (${{ matrix.arch }})
@@ -340,7 +340,7 @@ jobs:
     steps:
       # TODO: make sure this whole step doesnt count as a skip
       - uses: ausaccessfed/workflows/.github/actions/init@main
-        if: inputs.commands != '["skip"]'
+        if: inputs.commands != '["skip"]' && needs.init.outputs.IS_SLASH_DEPLOY == 'false'
         with:
           BRANCH_NAME: ${{ needs.init.outputs.BRANCH_NAME }}
           ROLE: ${{ secrets.ROLE }}
@@ -349,7 +349,7 @@ jobs:
           GITHUB_ACTOR: ${{ github.actor }}
 
       - name: Run
-        if: inputs.commands != '["skip"]'
+        if: inputs.commands != '["skip"]' && needs.init.outputs.IS_SLASH_DEPLOY == 'false'
         run: |
           docker pull ${{ needs.init.outputs.GITHUB_BRANCH_TEST_IMAGE_ID_TAG }}
           ${{ format(matrix.command, needs.init.outputs.GITHUB_BRANCH_TEST_IMAGE_ID_TAG) }}

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -99,6 +99,8 @@ jobs:
       IMAGE_ID: ${{ steps.env.outputs.IMAGE_ID }}
       INTEL_RUNNER: ${{ steps.env.outputs.INTEL_RUNNER }}
       ARM_RUNNER: ${{ steps.env.outputs.ARM_RUNNER }}
+      INTEL_RUNNER_CHEAP: ${{ steps.env.outputs.INTEL_RUNNER_CHEAP }}
+      ARM_RUNNER_CHEAP: ${{ steps.env.outputs.ARM_RUNNER_CHEAP }}
     name: init
     runs-on: ubuntu-latest
     if: inputs.event_name != 'issue_comment' || (contains(inputs.event_comment_body, '/deploy')  && contains(fromJSON(vars.ALLOWED_ACTORS), github.event.comment.user.login))
@@ -235,14 +237,16 @@ jobs:
             INTEL_RUNNER=ubuntu-latest
           fi
           echo "INTEL_RUNNER=$INTEL_RUNNER" >> $GITHUB_OUTPUT
+          echo "INTEL_RUNNER_CHEAP=ubuntu-latest" >> $GITHUB_OUTPUT
           echo "ARM_RUNNER=arm64-${{inputs.runner-cores}}-cores" >> $GITHUB_OUTPUT
+          echo "ARM_RUNNER_CHEAP=arm64-2-cores" >> $GITHUB_OUTPUT
 
   build-test:
     needs: [init]
     strategy:
       matrix:
         arch: ${{ fromJSON(inputs.platforms) }}
-    runs-on: ${{ (matrix.arch == 'linux/amd64' && needs.init.outputs.INTEL_RUNNER) || needs.init.outputs.ARM_RUNNER }}
+    runs-on: ${{ (matrix.arch == 'linux/amd64' && needs.init.outputs.INTEL_RUNNER_CHEAP) || needs.init.outputs.ARM_RUNNER_CHEAP }}
     name: Build Test Image
     steps:
       - uses: ausaccessfed/workflows/.github/actions/build@main
@@ -267,7 +271,7 @@ jobs:
 
   post-build-test:
     needs: [init, build-test]
-    runs-on: 'ubuntu-latest'
+    runs-on: ${{needs.init.outputs.INTEL_RUNNER_CHEAP}}
     steps:
       - uses: ausaccessfed/workflows/.github/actions/publish_manifest@main
         with:
@@ -284,7 +288,7 @@ jobs:
     strategy:
       matrix:
         arch: ${{ fromJSON(inputs.platforms) }}
-    runs-on: ${{ (matrix.arch == 'linux/amd64' && needs.init.outputs.INTEL_RUNNER) || needs.init.outputs.ARM_RUNNER }}
+    runs-on: ${{ (matrix.arch == 'linux/amd64' && needs.init.outputs.INTEL_RUNNER_CHEAP) || needs.init.outputs.ARM_RUNNER_CHEAP }}
     name: Build Production Image
     steps:
       - uses: ausaccessfed/workflows/.github/actions/build@main
@@ -309,7 +313,7 @@ jobs:
 
   post-build-production:
     needs: [init, build-production]
-    runs-on: 'ubuntu-latest'
+    runs-on: ${{needs.init.outputs.INTEL_RUNNER_CHEAP}}
     steps:
       - uses: ausaccessfed/workflows/.github/actions/publish_manifest@main
         with:
@@ -371,7 +375,7 @@ jobs:
     strategy:
       matrix:
         arch: ${{ fromJSON(inputs.platforms) }}
-    runs-on: ${{ (matrix.arch == 'linux/amd64' && needs.init.outputs.INTEL_RUNNER) || needs.init.outputs.ARM_RUNNER }}
+    runs-on: ${{ (matrix.arch == 'linux/amd64' && needs.init.outputs.INTEL_RUNNER_CHEAP) || needs.init.outputs.ARM_RUNNER_CHEAP }}
     env:
       DOCKLE_HOST: 'unix:///var/run/docker.sock'
     name: Dockle
@@ -389,7 +393,7 @@ jobs:
     strategy:
       matrix:
         arch: ${{ fromJSON(inputs.platforms) }}
-    runs-on: ${{ (matrix.arch == 'linux/amd64' && needs.init.outputs.INTEL_RUNNER) || needs.init.outputs.ARM_RUNNER }}
+    runs-on: ${{ (matrix.arch == 'linux/amd64' && needs.init.outputs.INTEL_RUNNER_CHEAP) || needs.init.outputs.ARM_RUNNER_CHEAP }}
     name: Hadolint
     steps:
       - uses: ausaccessfed/workflows/.github/actions/image_scanner@main
@@ -405,7 +409,7 @@ jobs:
     strategy:
       matrix:
         arch: ${{ fromJSON(inputs.platforms) }}
-    runs-on: ${{ (matrix.arch == 'linux/amd64' && needs.init.outputs.INTEL_RUNNER) || needs.init.outputs.ARM_RUNNER }}
+    runs-on: ${{ (matrix.arch == 'linux/amd64' && needs.init.outputs.INTEL_RUNNER_CHEAP) || needs.init.outputs.ARM_RUNNER_CHEAP }}
     name: Snyk
     steps:
       - uses: ausaccessfed/workflows/.github/actions/image_scanner@main
@@ -423,7 +427,7 @@ jobs:
     strategy:
       matrix:
         arch: ${{ fromJSON(inputs.platforms) }}
-    runs-on: ${{ (matrix.arch == 'linux/amd64' && needs.init.outputs.INTEL_RUNNER) || needs.init.outputs.ARM_RUNNER }}
+    runs-on: ${{ (matrix.arch == 'linux/amd64' && needs.init.outputs.INTEL_RUNNER_CHEAP) || needs.init.outputs.ARM_RUNNER_CHEAP }}
     name: Grype
     steps:
       - uses: ausaccessfed/workflows/.github/actions/image_scanner@main
@@ -441,7 +445,7 @@ jobs:
     strategy:
       matrix:
         arch: ${{ fromJSON(inputs.platforms) }}
-    runs-on: ${{ (matrix.arch == 'linux/amd64' && needs.init.outputs.INTEL_RUNNER) || needs.init.outputs.ARM_RUNNER }}
+    runs-on: ${{ (matrix.arch == 'linux/amd64' && needs.init.outputs.INTEL_RUNNER_CHEAP) || needs.init.outputs.ARM_RUNNER_CHEAP }}
     name: Trivy
     steps:
       - uses: ausaccessfed/workflows/.github/actions/image_scanner@main
@@ -459,7 +463,7 @@ jobs:
     strategy:
       matrix:
         arch: ${{ fromJSON(inputs.platforms) }}
-    runs-on: ${{ (matrix.arch == 'linux/amd64' && needs.init.outputs.INTEL_RUNNER) || needs.init.outputs.ARM_RUNNER }}
+    runs-on: ${{ (matrix.arch == 'linux/amd64' && needs.init.outputs.INTEL_RUNNER_CHEAP) || needs.init.outputs.ARM_RUNNER_CHEAP }}
     name: Pushing images to ecr
     steps:
       - uses: ausaccessfed/workflows/.github/actions/build@main
@@ -485,7 +489,7 @@ jobs:
   update-production-manifests:
     needs: [push-to-ecr, init]
     name: 'Update production manifests'
-    runs-on: ubuntu-latest
+    runs-on: ${{needs.init.outputs.INTEL_RUNNER_CHEAP}}
     steps:
       - uses: ausaccessfed/workflows/.github/actions/publish_manifest@main
         name: Updating GHCR manifests
@@ -511,7 +515,7 @@ jobs:
   update-terraform-manifests:
     needs: [update-production-manifests, init]
     name: 'Update terraform manifests'
-    runs-on: ubuntu-latest
+    runs-on: ${{needs.init.outputs.INTEL_RUNNER_CHEAP}}
     steps:
       ## no point making the gitops repo triggers async, they will fight each other
       ## and usually only 1 if statement is called anyway
@@ -568,7 +572,7 @@ jobs:
         update-terraform-manifests
       ]
     name: 'update-comments'
-    runs-on: ubuntu-latest
+    runs-on: ${{needs.init.outputs.INTEL_RUNNER_CHEAP}}
     if: needs.init.outputs.IS_SLASH_DEPLOY == 'true' && always()
     steps:
       - name: check for failures
@@ -636,7 +640,7 @@ jobs:
       ]
     if: always()
     name: 'finish'
-    runs-on: ubuntu-latest
+    runs-on: ${{needs.init.outputs.INTEL_RUNNER_CHEAP}}
     steps:
       - name: check for failures
         run: |

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -375,7 +375,7 @@ jobs:
     runs-on: ${{ (matrix.arch == 'linux/amd64' && needs.init.outputs.INTEL_RUNNER) || needs.init.outputs.ARM_RUNNER }}
     env:
       DOCKLE_HOST: 'unix:///var/run/docker.sock'
-    name: Running Dockle lint
+    name: Dockle
     steps:
       - uses: ausaccessfed/workflows/.github/actions/image_scanner@feature/more-build-adjustments
         with:
@@ -391,7 +391,7 @@ jobs:
       matrix:
         arch: ${{ fromJSON(inputs.platforms) }}
     runs-on: ${{ (matrix.arch == 'linux/amd64' && needs.init.outputs.INTEL_RUNNER) || needs.init.outputs.ARM_RUNNER }}
-    name: Running Hadolint
+    name: Hadolint
     steps:
       - uses: ausaccessfed/workflows/.github/actions/image_scanner@feature/more-build-adjustments
         with:
@@ -403,12 +403,12 @@ jobs:
 
   snyk-cve-scan:
     needs: [init, post-build-production]
-    # continue-on-error: true
+    continue-on-error: true
     strategy:
       matrix:
         arch: ${{ fromJSON(inputs.platforms) }}
     runs-on: ${{ (matrix.arch == 'linux/amd64' && needs.init.outputs.INTEL_RUNNER) || needs.init.outputs.ARM_RUNNER }}
-    name: Running Snyk cve scan
+    name: Snyk
     steps:
       - uses: ausaccessfed/workflows/.github/actions/image_scanner@feature/more-build-adjustments
         with:
@@ -421,12 +421,12 @@ jobs:
 
   grype-cve-scan:
     needs: [init, post-build-production]
-    # continue-on-error: true
+    continue-on-error: true
     strategy:
       matrix:
         arch: ${{ fromJSON(inputs.platforms) }}
     runs-on: ${{ (matrix.arch == 'linux/amd64' && needs.init.outputs.INTEL_RUNNER) || needs.init.outputs.ARM_RUNNER }}
-    name: Running Grype cve scan
+    name: Grype
     steps:
       - uses: ausaccessfed/workflows/.github/actions/image_scanner@feature/more-build-adjustments
         with:
@@ -439,12 +439,12 @@ jobs:
 
   trivy-cve-scan:
     needs: [init, post-build-production]
-    # continue-on-error: true
+    continue-on-error: true
     strategy:
       matrix:
         arch: ${{ fromJSON(inputs.platforms) }}
     runs-on: ${{ (matrix.arch == 'linux/amd64' && needs.init.outputs.INTEL_RUNNER) || needs.init.outputs.ARM_RUNNER }}
-    name: Running Trivy cve scan
+    name: Trivy
     steps:
       - uses: ausaccessfed/workflows/.github/actions/image_scanner@feature/more-build-adjustments
         with:

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -403,7 +403,7 @@ jobs:
 
   snyk-cve-scan:
     needs: [init, post-build-production]
-    continue-on-error: true
+    # continue-on-error: true
     strategy:
       matrix:
         arch: ${{ fromJSON(inputs.platforms) }}
@@ -421,7 +421,7 @@ jobs:
 
   grype-cve-scan:
     needs: [init, post-build-production]
-    continue-on-error: true
+    # continue-on-error: true
     strategy:
       matrix:
         arch: ${{ fromJSON(inputs.platforms) }}
@@ -439,7 +439,7 @@ jobs:
 
   trivy-cve-scan:
     needs: [init, post-build-production]
-    continue-on-error: true
+    # continue-on-error: true
     strategy:
       matrix:
         arch: ${{ fromJSON(inputs.platforms) }}

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -376,7 +376,7 @@ jobs:
       DOCKLE_HOST: 'unix:///var/run/docker.sock'
     name: Dockle
     steps:
-      - uses: ausaccessfed/workflows/.github/actions/image_scanner@feature/more-build-adjustments
+      - uses: ausaccessfed/workflows/.github/actions/image_scanner@main
         with:
           BRANCH_NAME: ${{ needs.init.outputs.BRANCH_NAME }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -392,7 +392,7 @@ jobs:
     runs-on: ${{ (matrix.arch == 'linux/amd64' && needs.init.outputs.INTEL_RUNNER) || needs.init.outputs.ARM_RUNNER }}
     name: Hadolint
     steps:
-      - uses: ausaccessfed/workflows/.github/actions/image_scanner@feature/more-build-adjustments
+      - uses: ausaccessfed/workflows/.github/actions/image_scanner@main
         with:
           BRANCH_NAME: ${{ needs.init.outputs.BRANCH_NAME }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -408,7 +408,7 @@ jobs:
     runs-on: ${{ (matrix.arch == 'linux/amd64' && needs.init.outputs.INTEL_RUNNER) || needs.init.outputs.ARM_RUNNER }}
     name: Snyk
     steps:
-      - uses: ausaccessfed/workflows/.github/actions/image_scanner@feature/more-build-adjustments
+      - uses: ausaccessfed/workflows/.github/actions/image_scanner@main
         with:
           BRANCH_NAME: ${{ needs.init.outputs.BRANCH_NAME }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -426,7 +426,7 @@ jobs:
     runs-on: ${{ (matrix.arch == 'linux/amd64' && needs.init.outputs.INTEL_RUNNER) || needs.init.outputs.ARM_RUNNER }}
     name: Grype
     steps:
-      - uses: ausaccessfed/workflows/.github/actions/image_scanner@feature/more-build-adjustments
+      - uses: ausaccessfed/workflows/.github/actions/image_scanner@main
         with:
           BRANCH_NAME: ${{ needs.init.outputs.BRANCH_NAME }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -444,7 +444,7 @@ jobs:
     runs-on: ${{ (matrix.arch == 'linux/amd64' && needs.init.outputs.INTEL_RUNNER) || needs.init.outputs.ARM_RUNNER }}
     name: Trivy
     steps:
-      - uses: ausaccessfed/workflows/.github/actions/image_scanner@feature/more-build-adjustments
+      - uses: ausaccessfed/workflows/.github/actions/image_scanner@main
         with:
           BRANCH_NAME: ${{ needs.init.outputs.BRANCH_NAME }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -338,7 +338,6 @@ jobs:
         ports:
           - '3306:3306'
     steps:
-      # TODO: make sure this whole step doesnt count as a skip
       - uses: ausaccessfed/workflows/.github/actions/init@main
         if: inputs.commands != '["skip"]' && needs.init.outputs.IS_SLASH_DEPLOY == 'false'
         with:
@@ -403,7 +402,6 @@ jobs:
 
   snyk-cve-scan:
     needs: [init, post-build-production]
-    continue-on-error: true
     strategy:
       matrix:
         arch: ${{ fromJSON(inputs.platforms) }}
@@ -418,10 +416,10 @@ jobs:
           IMAGE_TAG_FOR_SCAN: ${{ needs.init.outputs.GITHUB_BRANCH_LATEST_IMAGE_ID_TAG }}
           SCAN_NAME: snyk
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          SUPPRESS_FAILURE: true
 
   grype-cve-scan:
     needs: [init, post-build-production]
-    continue-on-error: true
     strategy:
       matrix:
         arch: ${{ fromJSON(inputs.platforms) }}
@@ -436,10 +434,10 @@ jobs:
           IMAGE_TAG_FOR_SCAN: ${{ needs.init.outputs.GITHUB_BRANCH_LATEST_IMAGE_ID_TAG }}
           SCAN_NAME: grype
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+          SUPPRESS_FAILURE: true
 
   trivy-cve-scan:
     needs: [init, post-build-production]
-    continue-on-error: true
     strategy:
       matrix:
         arch: ${{ fromJSON(inputs.platforms) }}
@@ -453,6 +451,7 @@ jobs:
           GITHUB_ACTOR: ${{ github.actor }}
           IMAGE_TAG_FOR_SCAN: ${{ needs.init.outputs.GITHUB_BRANCH_LATEST_IMAGE_ID_TAG }}
           SCAN_NAME: trivy
+          SUPPRESS_FAILURE: false
 
   push-to-ecr:
     needs: [init, commands, trivy-cve-scan, grype-cve-scan, snyk-cve-scan, hadolint, dockle-lint]

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -63,7 +63,7 @@ on:
         default: false
         type: boolean
       commands:
-        default: 'skip'
+        default: '["skip"]'
         type: string
       workflow_id:
         description: 'This is an id that is used for things like artifacts, needed when being called in a matrix'
@@ -356,6 +356,7 @@ jobs:
           - '3306:3306'
     steps:
       - uses: ausaccessfed/workflows/.github/actions/init@main
+        if: inputs.commands != '["skip"]'
         with:
           BRANCH_NAME: ${{ needs.init.outputs.BRANCH_NAME }}
           ROLE: ${{ secrets.ROLE }}
@@ -364,6 +365,7 @@ jobs:
           GITHUB_ACTOR: ${{ github.actor }}
 
       - name: Run
+        if: inputs.commands != '["skip"]'
         run: |
           docker pull ${{ needs.init.outputs.GITHUB_BRANCH_TEST_IMAGE_ID_TAG }}
           ${{ format(matrix.command, needs.init.outputs.GITHUB_BRANCH_TEST_IMAGE_ID_TAG) }}
@@ -432,14 +434,8 @@ jobs:
       #       true
 
   push-to-ecr:
-    needs: [init, commands, image-scan, image-lint]
-    if: |
-      always() &&
-      needs.init.outputs.SHOULD_PUSH_IMAGE_TO_ECR == 'true' &&
-      needs.init.result == 'success' &&
-      (needs.commands.result == 'success' || needs.commands.result == 'skipped') &&
-      needs.image-scan.result == 'success' &&
-      needs.image-lint.result == 'success'
+    needs: [init, commands, image-scan, hadolint, dockle-lint]
+    if: needs.init.outputs.SHOULD_PUSH_IMAGE_TO_ECR == 'true'
     strategy:
       matrix:
         arch: ${{ fromJSON(inputs.platforms) }}
@@ -470,11 +466,6 @@ jobs:
     needs: [push-to-ecr, init]
     name: 'Update production manifests'
     runs-on: ubuntu-latest
-    if: |
-      always() &&
-      needs.init.outputs.SHOULD_PUSH_IMAGE_TO_ECR == 'true' &&
-      needs.init.result == 'success' &&
-      needs.push-to-ecr.result == 'success'
     steps:
       - uses: ausaccessfed/workflows/.github/actions/publish_manifest@main
         name: Updating GHCR manifests
@@ -501,11 +492,6 @@ jobs:
     needs: [update-production-manifests, init]
     name: 'Update terraform manifests'
     runs-on: ubuntu-latest
-    if: |
-      always() &&
-      needs.init.outputs.SHOULD_PUSH_IMAGE_TO_ECR == 'true' &&
-      needs.init.result == 'success' &&
-      needs.update-production-manifests.result == 'success'
     steps:
       ## no point making the gitops repo triggers async, they will fight each other
       ## and usually only 1 if statement is called anyway
@@ -552,7 +538,8 @@ jobs:
         build-test,
         build-production,
         commands,
-        image-lint,
+        hadolint,
+        dockle-lint,
         image-scan,
         push-to-ecr,
         update-production-manifests,
@@ -616,7 +603,8 @@ jobs:
         build-test,
         build-production,
         commands,
-        image-lint,
+        hadolint,
+        dockle-lint,
         image-scan,
         push-to-ecr,
         update-production-manifests,
@@ -628,7 +616,7 @@ jobs:
     steps:
       - name: check for failures
         run: |
-          STRING="${{ needs.init.result }}${{ needs.build-test.result }}${{ needs.build-production.result }}${{ needs.commands.result }}${{ needs.image-lint.result }}${{ needs.image-scan.result }}${{ needs.push-to-ecr.result }}${{ needs.update-production-manifests.result }}${{ needs.update-terraform-manifests.result }}"
+          STRING="${{ needs.init.result }}${{ needs.build-test.result }}${{ needs.build-production.result }}${{ needs.commands.result }}${{ needs.hadolint.result }}${{ needs.dockle-lint.result }}${{ needs.image-scan.result }}${{ needs.push-to-ecr.result }}${{ needs.update-production-manifests.result }}${{ needs.update-terraform-manifests.result }}"
           if [ "$(echo "$STRING" | grep "failure" || echo "")" != "" ]; then
             exit 1
           fi

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -46,10 +46,14 @@ on:
       platforms:
         default: "['linux/amd64']"
         type: string
-      runner-cores:
-        description: 'Provide the amount of cores wanted, if 2 then defaults to free runner for intel'
-        default: '2'
+      runner_cores:
+        description: 'Provide the amount of cores wanted, if the powerful runner is requested, defaults to 8'
+        default: '8'
         type: string
+      use_better_runner_for_builds:
+        description: 'if true, powerful runner will be used for build docker images'
+        default: false
+        type: boolean
       development_environments:
         default: 'development'
         type: string
@@ -232,13 +236,13 @@ jobs:
 
           # Note this assumes runners exist given the naming ARCH-NUM_CORES-cores
           # TODO: make this work for more than intel and arm? maybe we dont need anything else
-          INTEL_RUNNER=amd64-${{inputs.runner-cores}}-cores
-          if [ "${{inputs.runner-cores}}" == "2" ]; then
+          INTEL_RUNNER=amd64-${{inputs.runner_cores}}-cores
+          if [ "${{inputs.runner_cores}}" == "2" ]; then
             INTEL_RUNNER=ubuntu-latest
           fi
           echo "INTEL_RUNNER=$INTEL_RUNNER" >> $GITHUB_OUTPUT
           echo "INTEL_RUNNER_CHEAP=ubuntu-latest" >> $GITHUB_OUTPUT
-          echo "ARM_RUNNER=arm64-${{inputs.runner-cores}}-cores" >> $GITHUB_OUTPUT
+          echo "ARM_RUNNER=arm64-${{inputs.runner_cores}}-cores" >> $GITHUB_OUTPUT
           echo "ARM_RUNNER_CHEAP=arm64-2-cores" >> $GITHUB_OUTPUT
 
   build-test:
@@ -246,7 +250,7 @@ jobs:
     strategy:
       matrix:
         arch: ${{ fromJSON(inputs.platforms) }}
-    runs-on: ${{ (matrix.arch == 'linux/amd64' && needs.init.outputs.INTEL_RUNNER_CHEAP) || needs.init.outputs.ARM_RUNNER_CHEAP }}
+    runs-on: ${{ (matrix.arch == 'linux/amd64' && ((inputs.use_better_runner_for_builds && needs.init.outputs.INTEL_RUNNER) || needs.init.outputs.INTEL_RUNNER_CHEAP)) || ((inputs.use_better_runner_for_builds && needs.init.outputs.ARM_RUNNER) || needs.init.outputs.ARM_RUNNER_CHEAP) }}
     name: Build Test Image
     steps:
       - uses: ausaccessfed/workflows/.github/actions/build@main
@@ -288,7 +292,7 @@ jobs:
     strategy:
       matrix:
         arch: ${{ fromJSON(inputs.platforms) }}
-    runs-on: ${{ (matrix.arch == 'linux/amd64' && needs.init.outputs.INTEL_RUNNER_CHEAP) || needs.init.outputs.ARM_RUNNER_CHEAP }}
+    runs-on: ${{ (matrix.arch == 'linux/amd64' && ((inputs.use_better_runner_for_builds && needs.init.outputs.INTEL_RUNNER) || needs.init.outputs.INTEL_RUNNER_CHEAP)) || ((inputs.use_better_runner_for_builds && needs.init.outputs.ARM_RUNNER) || needs.init.outputs.ARM_RUNNER_CHEAP) }}
     name: Build Production Image
     steps:
       - uses: ausaccessfed/workflows/.github/actions/build@main
@@ -332,7 +336,7 @@ jobs:
       matrix:
         arch: ${{ (inputs.commands != '["skip"]' && needs.init.outputs.IS_SLASH_DEPLOY == 'false' &&  fromJSON(inputs.platforms)) || fromJSON('["linux/amd64"]') }}
         command: ${{ fromJSON(inputs.commands) }}
-    runs-on: ${{ (matrix.arch == 'linux/amd64' && ((contains(matrix.command, 'MORE_POWER') && needs.init.outputs.INTEL_RUNNER) || needs.init.outputs.INTEL_RUNNER_CHEAP)) || ((contains(matrix.command, 'MORE_POWER') && needs.init.outputs.ARM_RUNNER) || needs.init.outputs.ARM_RUNNER_CHEAP) }}
+    runs-on: ${{ (matrix.arch == 'linux/amd64' && ((contains(matrix.command, 'BETTER_RUNNER') && needs.init.outputs.INTEL_RUNNER) || needs.init.outputs.INTEL_RUNNER_CHEAP)) || ((contains(matrix.command, 'BETTER_RUNNER') && needs.init.outputs.ARM_RUNNER) || needs.init.outputs.ARM_RUNNER_CHEAP) }}
     name: ${{ format(matrix.command, '') }} (${{ matrix.arch }})
     services:
       mysql:


### PR DESCRIPTION
Renames, reworks runner_cores, this now controls the "powerful runner" cores

This will only be used if the command contains `BETTER_RUNNER` or if the `use_better_runner_for_builds` input is provided  otherwise defaults to arm 2 core or free runners