### PR TITLE
allow commands to fail-fast

### DIFF
--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -332,7 +332,6 @@ jobs:
   commands:
     needs: [init, post-build-test]
     strategy:
-      fail-fast: false
       matrix:
         arch: ${{ (inputs.commands != '["skip"]' && needs.init.outputs.IS_SLASH_DEPLOY == 'false' &&  fromJSON(inputs.platforms)) || fromJSON('["linux/amd64"]') }}
         command: ${{ fromJSON(inputs.commands) }}


### PR DESCRIPTION
This just avoids wasting extra minutes on other tasks when a quicker one fails early