### PR TITLE
need to skip final if init was skipped

### DIFF
--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -656,7 +656,7 @@ jobs:
         update-production-manifests,
         update-terraform-manifests
       ]
-    if: always()
+    if: always() && needs.init.result != 'skipped'
     name: 'finish'
     runs-on: ${{needs.init.outputs.INTEL_RUNNER_CHEAP}}
     steps:


### PR DESCRIPTION
just avoids the workflow fails when you comment and it doesnt contain the keywords