### PR TITLE
If PR labels are missing, check again

### DIFF
--- a/.github/workflows/pr-housekeeping.yml
+++ b/.github/workflows/pr-housekeeping.yml
@@ -15,9 +15,6 @@ jobs:
       GITHUB_TOKEN: ${{secrets.REPO_SCOPED_TOKEN}}
     name: 'PR housekeeping'
     steps:
-      - name: wait for labels
-        run: |
-          sleep 30
       - uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           github-token: ${{secrets.REPO_SCOPED_TOKEN}}
@@ -37,8 +34,6 @@ jobs:
                     repo
                 }
             } = context
-            const labelNames = labels.map(x => x.name)
-            const allowedLabels = "${{inputs.AUTO_MERGEABLE_LABELS}}".split(",")
 
             // Assign to author
             await github.rest.issues.addAssignees({
@@ -61,7 +56,30 @@ jobs:
                     pullRequestId: node_id, mergeMethod: "SQUASH"
                 })
 
-                //If anything is common between the two list of labels auto approve
+                let labelNames = labels.map(x => x.name)
+                if (labelNames.length == 0) {
+                  // We occasionally hit this case because labels aren't always present the instant the PR is created.
+                  // Let's try fetching them again for up to 50 seconds. We can trust the labels will eventually appear
+                  // because we know this is a Renovate PR, and Renovate always adds labels.
+                  const maxWaitTime = 50000
+                  let currentWaitTime = 1000
+                  let totalWaitTime = 0
+
+                  while (labelNames.length == 0 && totalWaitTime < maxWaitTime) {
+                    await new Promise(resolve => setTimeout(resolve, currentWaitTime))
+                    totalWaitTime += currentWaitTime
+                    currentWaitTime *= 2 // Back-off exponentially
+
+                    const { data: pullRequest } = await github.rest.pulls.get({
+                        owner,
+                        repo,
+                        pull_number
+                    })
+                    labelNames = pullRequest.labels.map(x => x.name)
+                  }
+                }
+
+                const allowedLabels = "${{inputs.AUTO_MERGEABLE_LABELS}}".split(",")
                 if (labelNames.some(item => allowedLabels.includes(item))) {
                     // Autoapprove
                     await github.rest.pulls.createReview({


### PR DESCRIPTION
Renovate PRs occasionally fail to auto-approve, e.g. https://github.com/ausaccessfed/federationmanager/pull/3908. We think this is because labels aren't always present the instant this workflow runs. To work around this, we now try fetching labels for Renovate PRs for up to 50 seconds.

We stop after 50 seconds so we don't cross GitHub's minute billing boundary.

Resolves #118 (hopefully).