### PR TITLE
Fix empty pr disributions

### DIFF
--- a/scripts/workflow-distributor.js
+++ b/scripts/workflow-distributor.js
@@ -289,7 +289,7 @@ const updateFileTreeObject = async ({ baseBranch, repo, parsedFile }) => {
 
   newContent = handlePartial({ currentContentBase64, newContent })
 
-  if (currentContentBase64) {
+  if (currentContentBase64 != undefined) {
     // Assuming currentContentBase64 and newContent are defined
     const currentContent = Buffer.from(currentContentBase64, 'base64').toString('utf-8');
 


### PR DESCRIPTION
one last change required to avoid empty prs

one overlooked fact from last fix that empty strings will count as a new file but we can bootstrap empty files