### PR TITLE
Adjust main branch builds grouping

### DIFF
--- a/.github/workflows/distributions/.github/workflows/deploy.yml
+++ b/.github/workflows/distributions/.github/workflows/deploy.yml
@@ -11,7 +11,7 @@ jobs:
   all:
     concurrency:
       group: ${{ github.event.comment.id }}-${{ github.event_name }}-${{ github.ref_name }}-build
-      cancel-in-progress: ${{ github.ref_name == 'master' || github.ref_name == 'main' }}
+      cancel-in-progress: ${{ github.ref_name != 'master' && github.ref_name != 'main' }}
     permissions:
       id-token: write
       contents: read

--- a/.github/workflows/distributions/.github/workflows/deploy.yml
+++ b/.github/workflows/distributions/.github/workflows/deploy.yml
@@ -10,8 +10,8 @@ on:
 jobs:
   all:
     concurrency:
-      group: ${{ github.event.comment.id }}-${{ github.event_name }}-${{ ( github.ref_name == 'master' || github.ref_name == 'main' ) && github.sha || github.ref_name }}-build
-      cancel-in-progress: true
+      group: ${{ github.event.comment.id }}-${{ github.event_name }}-${{ github.ref_name }}-build
+      cancel-in-progress: ${{ github.ref_name == 'master' || github.ref_name == 'main' }}
     permissions:
       id-token: write
       contents: read


### PR DESCRIPTION
instead of running a group per commit
run 1 group for main branch but don't cancel running

This means they run in sequence avoiding all race conditions

closes https://github.com/ausaccessfed/aaf-terraform/issues/2293