### PR TITLE
Let matthew-puku self-approve tidyings

### DIFF
--- a/trusted_keys/trusted_self_approvers
+++ b/trusted_keys/trusted_self_approvers
@@ -1,0 +1,1 @@
+matthew-puku


### PR DESCRIPTION
Per the process in [the Slab document](https://australian-access-federation.slab.com/posts/tidy-licenses-zt1pfvqc):

## Three PRs which _juuust_ needed review

- https://github.com/ausaccessfed/aaf-terraform/pull/3961
  - even though IN THEORY this only impacts dev, it's a complex change which passes through the TF file generation/manifests flow. We screw these up all the time.
  - Also, it impacts AAF developer workflow.
- https://github.com/ausaccessfed/federationmanager/pull/3947
  - Mostly affects the test suite, but also contains a tiny behaviour change. Changing tests at the same time we change app code always carries some risks. (Just ask CrowdStrike)
- https://github.com/ausaccessfed/aaf-terraform/pull/3817
  - In theory this NAT gateway was "proven" unused by the preceeding PRs in development and test. I think this is a borderline case, in future we could consider this sort of thing to be tidying. But until we agree on that as a team, it's not.

## Three PRs which could've skipped review

- https://github.com/ausaccessfed/federationmanager/pull/3946
  - We agreed as a team that feature-flag removal was OK.
- https://github.com/ausaccessfed/federationmanager/pull/3886
  - Removing dead code is one of the tidyings described in the book.
  - We can be very sure the code is actually dead because FM has a great test suite which reaches 100% coverage with very little mocking.
- https://github.com/ausaccessfed/aaf-terraform/pull/3531
  - Trivial update to documentation.