### PR TITLE
ADjust summariser

### DIFF
--- a/.github/actions/summarise/action.yaml
+++ b/.github/actions/summarise/action.yaml
@@ -73,4 +73,6 @@ runs:
     - id: throw_error
       shell: bash
       if: inputs.SUCCESS == 'failure' || inputs.SUCCESS == 'false'
-      run: exit 1
+      run: |
+        cat "${{ inputs.OUTPUT_FILE }}"
+        exit 1


### PR DESCRIPTION
adds a cat to summarize on failure 
 so that clicking links shows error, otherwise your forced to always go to the summary to find the error