### PR TITLE
Fix summarise text for skips

### DIFF
--- a/.github/actions/summarise/action.yaml
+++ b/.github/actions/summarise/action.yaml
@@ -33,6 +33,9 @@ runs:
     - id: split_file
       shell: bash
       run: |
+        if [ ! -e "${{ inputs.OUTPUT_FILE }}" ]; then
+          echo "Output file not found." > ${{ inputs.OUTPUT_FILE }}
+        fi
         FILE_SIZE=$(stat -c%s "${{ inputs.OUTPUT_FILE }}")
         CHUNK_SIZE=$((900 * 1024)) # 700KB in bytes
 


### PR DESCRIPTION
prefill the output txt with no output message to avoid skips failing
i.e https://github.com/ausaccessfed/shib-sp/actions/runs/10571830515/job/29288622486?pr=160