### PR TITLE
Summaries attempt to run commands if output has double quotes in it somtimes

### DIFF
--- a/.github/actions/summarise/action.yaml
+++ b/.github/actions/summarise/action.yaml
@@ -36,6 +36,7 @@ runs:
         if [ ! -e "${{ inputs.OUTPUT_FILE }}" ]; then
           echo "Output file not found." > ${{ inputs.OUTPUT_FILE }}
         fi
+        sed -i "s/\"/'/g" "${{ inputs.OUTPUT_FILE }}"
         FILE_SIZE=$(stat -c%s "${{ inputs.OUTPUT_FILE }}")
         CHUNK_SIZE=$((900 * 1024)) # 700KB in bytes
 


### PR DESCRIPTION
replace all double quotes with single

i.e https://github.com/ausaccessfed/verifid/actions/runs/10571832884/job/29288828609?pr=524