### PR TITLE
Fix syntax error in self-approve-tidying.yml

### DIFF
--- a/.github/workflows/self-approve-tidying.yml
+++ b/.github/workflows/self-approve-tidying.yml
@@ -58,7 +58,7 @@ jobs:
             } = context
 
             await github.rest.pulls.createReview({
-                event: "APPROVE"
+                event: "APPROVE",
                 owner,
                 repo,
                 pull_number


### PR DESCRIPTION
Bug introduced in ee4d336. When I reordered the object I forgot to adjust the commas.

I should avoid coding without IDE assistance 😄 