### PR TITLE
Allow base images other than ruby-base

### DIFF
--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -5,6 +5,9 @@ on:
       ecr_repository:
         required: true
         type: string
+      base_image_repository:
+        default: 'ruby-base'
+        type: string
       dev_url:
         default: ''
         type: string
@@ -202,7 +205,7 @@ jobs:
 
           RUBY_VERSION=$(${{ inputs.version_command }})
           echo "RUBY_VERSION=$RUBY_VERSION" >> $GITHUB_OUTPUT
-          BASE_IMAGE="$GITHUB_REGISTRY_ROOT_REF/ruby-base:${RUBY_VERSION}"
+          BASE_IMAGE="$GITHUB_REGISTRY_ROOT_REF/${{ inputs.base_image_repository }}:${RUBY_VERSION}"
           echo "BASE_IMAGE=$BASE_IMAGE" >> $GITHUB_OUTPUT
 
           # Strip git ref prefix from version

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -98,7 +98,7 @@ jobs:
       IS_MONTHLY_BUILD: ${{ steps.env.outputs.IS_MONTHLY_BUILD }}
       IS_DEFAULT_BRANCH_PUSH: ${{ steps.env.outputs.IS_DEFAULT_BRANCH_PUSH }}
       BRANCH_NAME: ${{ steps.branch.outputs.BRANCH_NAME }}
-      RUBY_VERSION: ${{ steps.env.outputs.RUBY_VERSION }}
+      IMAGE_VERSION: ${{ steps.env.outputs.IMAGE_VERSION }}
       BASE_IMAGE: ${{ steps.env.outputs.BASE_IMAGE }}
       ECR_IMAGE_ID_TAG: ${{ steps.env.outputs.ECR_IMAGE_ID_TAG }}
       ECR_IMAGE_TAG: ${{ steps.env.outputs.ECR_IMAGE_TAG }}
@@ -203,9 +203,9 @@ jobs:
 
           echo "PUBLISH_APP_IMAGE_ID_TAG=$GITHUB_REGISTRY_ROOT_REF/publish_app:latest" >> $GITHUB_OUTPUT
 
-          RUBY_VERSION=$(${{ inputs.version_command }})
-          echo "RUBY_VERSION=$RUBY_VERSION" >> $GITHUB_OUTPUT
-          BASE_IMAGE="$GITHUB_REGISTRY_ROOT_REF/${{ inputs.base_image_repository }}:${RUBY_VERSION}"
+          IMAGE_VERSION=$(${{ inputs.version_command }})
+          echo "IMAGE_VERSION=$IMAGE_VERSION" >> $GITHUB_OUTPUT
+          BASE_IMAGE="$GITHUB_REGISTRY_ROOT_REF/${{ inputs.base_image_repository }}:${IMAGE_VERSION}"
           echo "BASE_IMAGE=$BASE_IMAGE" >> $GITHUB_OUTPUT
 
           # Strip git ref prefix from version
@@ -282,7 +282,7 @@ jobs:
           GITHUB_ACTOR: ${{ github.actor }}
           IMAGE_PLATFORMS: ${{ matrix.arch }}
           IMAGE_BUILD_ARGS: |
-            RUBY_VERSION=${{ needs.init.outputs.RUBY_VERSION }}
+            RUBY_VERSION=${{ needs.init.outputs.IMAGE_VERSION }}
             BASE_IMAGE=${{ needs.init.outputs.BASE_IMAGE }}
           IMAGE_TARGET: development
           IMAGE_CACHE_TO: ${{ needs.init.outputs.GITHUB_BRANCH_TEST_IMAGE_ID_TAG }}
@@ -324,7 +324,7 @@ jobs:
           GITHUB_ACTOR: ${{ github.actor }}
           IMAGE_PLATFORMS: ${{ matrix.arch }}
           IMAGE_BUILD_ARGS: |
-            RUBY_VERSION=${{ needs.init.outputs.RUBY_VERSION }}
+            RUBY_VERSION=${{ needs.init.outputs.IMAGE_VERSION }}
             BASE_IMAGE=${{ needs.init.outputs.BASE_IMAGE }}
             RELEASE_VERSION=${{ needs.init.outputs.IMAGE_TAG }}
           IMAGE_TARGET: production
@@ -532,7 +532,7 @@ jobs:
           GITHUB_ACTOR: ${{ github.actor }}
           IMAGE_PLATFORMS: ${{ matrix.arch }}
           IMAGE_BUILD_ARGS: |
-            RUBY_VERSION=${{ needs.init.outputs.RUBY_VERSION }}
+            RUBY_VERSION=${{ needs.init.outputs.IMAGE_VERSION }}
             BASE_IMAGE=${{ needs.init.outputs.BASE_IMAGE }}
             RELEASE_VERSION=${{ needs.init.outputs.IMAGE_TAG }}
           IMAGE_TARGET: production


### PR DESCRIPTION
Required for https://github.com/ausaccessfed/shib-idp/pull/3, which uses shib-sp.

Note: perhaps RUBY_VERSION should be renamed as well. I believe `ruby-base` is the only direct consumer of the var.