### PR TITLE
Fail finish step when intermediate step cancelled

### DIFF
--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -714,6 +714,4 @@ jobs:
       - name: check for failures
         run: |
           STRING="${{ needs.init.result }}${{ needs.build-test.result }}${{ needs.build-production.result }}${{ needs.test-image-commands.result }}${{ needs.production-image-commands.result }}${{ needs.hadolint.result }}${{ needs.dockle-lint.result }}${{ needs.trivy-repo-scan.result }}${{ needs.trivy-cve-scan.result }}${{ needs.grype-cve-scan.result }}${{ needs.snyk-cve-scan.result }}${{ needs.push-to-ecr.result }}${{ needs.update-production-manifests.result }}${{ needs.update-terraform-manifests.result }}"
-          if [ "$(echo "$STRING" | grep -e "failure" -e "cancelled" || echo "")" != "" ]; then
-            exit 1
-          fi
+          echo successskippedsuccess | grep -E '^(success|skipped)+$'

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -714,6 +714,6 @@ jobs:
       - name: check for failures
         run: |
           STRING="${{ needs.init.result }}${{ needs.build-test.result }}${{ needs.build-production.result }}${{ needs.test-image-commands.result }}${{ needs.production-image-commands.result }}${{ needs.hadolint.result }}${{ needs.dockle-lint.result }}${{ needs.trivy-repo-scan.result }}${{ needs.trivy-cve-scan.result }}${{ needs.grype-cve-scan.result }}${{ needs.snyk-cve-scan.result }}${{ needs.push-to-ecr.result }}${{ needs.update-production-manifests.result }}${{ needs.update-terraform-manifests.result }}"
-          if [ "$(echo "$STRING" | grep "failure" || echo "")" != "" ]; then
+          if [ "$(echo "$STRING" | grep -e "failure" -e "cancelled" || echo "")" != "" ]; then
             exit 1
           fi

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -714,4 +714,4 @@ jobs:
       - name: check for failures
         run: |
           STRING="${{ needs.init.result }}${{ needs.build-test.result }}${{ needs.build-production.result }}${{ needs.test-image-commands.result }}${{ needs.production-image-commands.result }}${{ needs.hadolint.result }}${{ needs.dockle-lint.result }}${{ needs.trivy-repo-scan.result }}${{ needs.trivy-cve-scan.result }}${{ needs.grype-cve-scan.result }}${{ needs.snyk-cve-scan.result }}${{ needs.push-to-ecr.result }}${{ needs.update-production-manifests.result }}${{ needs.update-terraform-manifests.result }}"
-          echo successskippedsuccesscancelledsuccess | grep -E '^(success|skipped)+$'
+          echo "$STRING" | grep -E '^(success|skipped)+$'

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -714,4 +714,4 @@ jobs:
       - name: check for failures
         run: |
           STRING="${{ needs.init.result }}${{ needs.build-test.result }}${{ needs.build-production.result }}${{ needs.test-image-commands.result }}${{ needs.production-image-commands.result }}${{ needs.hadolint.result }}${{ needs.dockle-lint.result }}${{ needs.trivy-repo-scan.result }}${{ needs.trivy-cve-scan.result }}${{ needs.grype-cve-scan.result }}${{ needs.snyk-cve-scan.result }}${{ needs.push-to-ecr.result }}${{ needs.update-production-manifests.result }}${{ needs.update-terraform-manifests.result }}"
-          echo successskippedsuccess | grep -E '^(success|skipped)+$'
+          echo successskippedsuccesscancelledsuccess | grep -E '^(success|skipped)+$'


### PR DESCRIPTION
Currently, if you let the init step of a deployment workflow complete, then cancel further steps, you'll get a result string something like:

`successcancelledcancelledcancelledcancelledcancelledcancelledcancelledcancelledcancelledcancelledcancelledcancelledcancelled`

Because this doesn't contain the substring "failed", the workflow is incorrectly marked as finished and merging is allowed.

Example here: https://github.com/ausaccessfed/shib-idp/actions/runs/10676140602/job/29589840881?pr=3

To fix this, grep for "cancelled" or "failed" in the result string, not just "failed".