### PR TITLE
allow publish add to wait up to 10 mins for the image to exist

### DIFF
--- a/.github/actions/publish_app/action.yaml
+++ b/.github/actions/publish_app/action.yaml
@@ -35,8 +35,12 @@ runs:
     - name: Check if there's an app image corresponding to this commit
       shell: bash
       run: |
-        aws ecr describe-images --repository-name "${{ inputs.ECR_REPOSITORY }}" \
-          --image-ids imageTag=${{ inputs.PUBLISH_IMAGE_TAG }}
+        ## Loop 5 times with 2 minute timeouts until it finds an image
+        for i in {1..5}; do
+          aws ecr describe-images --repository-name "${{ inputs.ECR_REPOSITORY }}" \
+            --image-ids imageTag=${{ inputs.PUBLISH_IMAGE_TAG }} && break
+          sleep 120
+        done
 
     - name: Update GitOps Repo to deploy in development
       shell: bash


### PR DESCRIPTION
Avoid for example the case where scheduled sync runs and it doesn't find the image as the master commit is still running.

Shouldnt be an issue but when you have an app pinned to a dev branch that is also blatted over the weekend so causes the morning to fail to spin up