### PR TITLE
platform is implict based on OS running

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -16,7 +16,7 @@ inputs:
   GITHUB_ACTOR:
     description: 'github actor used to auth to ghcr'
     default: ''
-  IMAGE_PLATFORMS:
+  IMAGE_PLATFORM:
     description: 'cache from strings'
     required: true
   IMAGE_BUILD_ARGS:
@@ -74,7 +74,7 @@ runs:
       id: envs
       shell: bash
       run: |
-        MATRIX_CLEANED="$(echo "${{ inputs.IMAGE_PLATFORMS }}" | tr / _)"
+        MATRIX_CLEANED="$(echo "${{ inputs.IMAGE_PLATFORM }}" | tr / _)"
 
         if [ "${{inputs.IMAGE_CACHE_FROM}}" != "" ]; then
           echo "IMAGE_CACHE_FROM<<EOF" >> $GITHUB_OUTPUT
@@ -106,7 +106,6 @@ runs:
         cache-from: ${{ steps.envs.outputs.IMAGE_CACHE_FROM }}
         cache-to: ${{ steps.envs.outputs.IMAGE_CACHE_TO }}
         build-args: ${{ inputs.IMAGE_BUILD_ARGS }}
-        platforms: ${{ inputs.IMAGE_PLATFORMS }}
         provenance: false
         sbom: false
 

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -280,7 +280,7 @@ jobs:
           ECR_REPOSITORY: ${{ inputs.ecr_repository }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}
-          IMAGE_PLATFORMS: ${{ matrix.arch }}
+          IMAGE_PLATFORM: ${{ matrix.arch }}
           IMAGE_BUILD_ARGS: |
             RUBY_VERSION=${{ needs.init.outputs.IMAGE_VERSION }}
             BASE_IMAGE=${{ needs.init.outputs.BASE_IMAGE }}
@@ -322,7 +322,7 @@ jobs:
           ECR_REPOSITORY: ${{ inputs.ecr_repository }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}
-          IMAGE_PLATFORMS: ${{ matrix.arch }}
+          IMAGE_PLATFORM: ${{ matrix.arch }}
           IMAGE_BUILD_ARGS: |
             RUBY_VERSION=${{ needs.init.outputs.IMAGE_VERSION }}
             BASE_IMAGE=${{ needs.init.outputs.BASE_IMAGE }}
@@ -530,7 +530,7 @@ jobs:
           ECR_REPOSITORY: ${{ inputs.ecr_repository }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}
-          IMAGE_PLATFORMS: ${{ matrix.arch }}
+          IMAGE_PLATFORM: ${{ matrix.arch }}
           IMAGE_BUILD_ARGS: |
             RUBY_VERSION=${{ needs.init.outputs.IMAGE_VERSION }}
             BASE_IMAGE=${{ needs.init.outputs.BASE_IMAGE }}


### PR DESCRIPTION
In an attempt to make aws ecr happy remove platforms from the build, 

As we only really ever have 1 platform context anyway and is implict based on the runnner