### PR TITLE
Let waldofouche self-approve tidyings

### DIFF
--- a/trusted_keys/trusted_self_approvers
+++ b/trusted_keys/trusted_self_approvers
@@ -1,1 +1,2 @@
 matthew-puku
+waldofouche


### PR DESCRIPTION
Per the process in [the Slab document](https://australian-access-federation.slab.com/posts/tidy-licenses-zt1pfvqc):

## Three PRs which _juuust_ needed review

-  https://github.com/ausaccessfed/federationmanager/pull/4055 
     - We agreed as a team that feature-flag removal was OK.
     - In general PRs like these are straight forward, however this one just needed a few small nits to get across the line which were more about the implementation, than just the removal of feature flag
- https://github.com/ausaccessfed/aaf-terraform/pull/4089 
  - A pretty simple code change per-se, but it needed a bit of extra testing to verify it worked as expected so the extra pair of eyes was just a sanity check imo
- https://github.com/ausaccessfed/federationmanager/pull/4252 
  - Refactor of existing methods out to smaller, dedicated classes/controllers. The nits in the PR were warranted, however our strong test suite gave confidence in the rollout 

## Three PRs which could've skipped review

- https://github.com/ausaccessfed/federationmanager/pull/4228 
   -  Trivial update to a decorator that only global admins can see
-  https://github.com/ausaccessfed/federationmanager/pull/4011
   - Adding back CI checks that were accidental removed as part of a refactor
- https://github.com/ausaccessfed/aaf-terraform/pull/4074
  - Sanity PR to ensure that the drift between grafana dashbaords and terraform does not stray too far apart 


## Bonus

- https://github.com/ausaccessfed/oidc_relying_party_example
  - Almost all the PRs to this repo could have skipped review tbh 