### PR TITLE
Label self-approved tidyings as technical quality

### DIFF
--- a/.github/workflows/self-approve-tidying.yml
+++ b/.github/workflows/self-approve-tidying.yml
@@ -40,7 +40,7 @@ jobs:
             fi
           done
 
-      - name: Approve
+      - name: Approve and label
         uses: actions/github-script@60a0d83039c74a4aee543508d2ffcb1c3799cdea # v7.0.1
         with:
           github-token: ${{secrets.REPO_SCOPED_TOKEN}}
@@ -62,4 +62,13 @@ jobs:
                 owner,
                 repo,
                 pull_number
+            })
+
+            // By definition, tidyings are purely technical quality improvements. We can apply the label automatically
+            // to save the author a few clicks.
+            await github.rest.issues.addLabels({
+                owner,
+                repo,
+                issue_number: pull_number,
+                labels: ["technical quality"]
             })


### PR DESCRIPTION
tidyings are technical quality changes by definition, so we can save some clicking by applying this label on behalf of the dev.

Resolves #340 