### PR TITLE
Feature/adjust publish app to allow for adhoc specifcity

### DIFF
--- a/.github/actions/publish_app/action.yaml
+++ b/.github/actions/publish_app/action.yaml
@@ -22,6 +22,9 @@ inputs:
   PUBLISH_IMAGE_TAG:
     description: 'Tag to update manifests with'
     required: true
+  IS_ADHOC:
+    description: 'If true, override the provided PUBLISH_ENVIRONMENTS, irrelevant of adhoc-ness'
+    default: 'false'
 runs:
   using: 'composite'
   steps:
@@ -51,4 +54,5 @@ runs:
           -e IMAGE_TAG="${{ inputs.PUBLISH_IMAGE_TAG }}" \
           -e ENVIRONMENTS="${{ inputs.PUBLISH_ENVIRONMENTS }}" \
           -e ECR_REPOSITORY="${{ inputs.ECR_REPOSITORY }}" \
+          -e IS_ADHOC="${{ inputs.IS_ADHOC }}" \
           ghcr.io/ausaccessfed/publish_app:latest

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -57,14 +57,11 @@ on:
         description: 'if true, powerful runner will be used for build docker images'
         default: false
         type: boolean
-      development_environments:
+      adhoc_environments:
         default: 'development'
         type: string
-      test_environments:
-        default: ''
-        type: string
       production_environments:
-        default: 'test,production'
+        default: 'development,test,production'
         type: string
       save_test_artifacts:
         default: false
@@ -565,29 +562,18 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}
 
-      - name: Update GitOps Repo to trigger deploys for test
-        if: inputs.test_environments != '' && needs.init.outputs.IS_DEFAULT_DEVELOPMENT_BRANCH_PUSH == 'true'
-        uses: ausaccessfed/workflows/.github/actions/publish_app@main
-        with:
-          ROLE: ${{ secrets.ROLE }}
-          ECR_REPOSITORY: ${{ inputs.ecr_repository }}
-          PUBLISH_IMAGE_TAG: ${{ needs.init.outputs.ECR_IMAGE_TAG }}
-          PUBLISH_APPS: ${{ needs.init.outputs.PROJECTS }}
-          PUBLISH_ENVIRONMENTS: ${{ inputs.test_environments }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_ACTOR: ${{ github.actor }}
-
       - name: Update GitOps Repo to trigger deploys for development
-        if: inputs.development_environments != '' && needs.init.outputs.IS_SLASH_DEPLOY == 'true'
+        if: inputs.adhoc_environments != '' && needs.init.outputs.IS_SLASH_DEPLOY == 'true'
         uses: ausaccessfed/workflows/.github/actions/publish_app@main
         with:
           ROLE: ${{ secrets.ROLE }}
           ECR_REPOSITORY: ${{ inputs.ecr_repository }}
           PUBLISH_IMAGE_TAG: ${{ needs.init.outputs.ECR_IMAGE_TAG }}
           PUBLISH_APPS: ${{ needs.init.outputs.PROJECTS }}
-          PUBLISH_ENVIRONMENTS: ${{ inputs.development_environments }}
+          PUBLISH_ENVIRONMENTS: ${{ inputs.adhoc_environments }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}
+          IS_ADHOC: 'true'
 
   update-comments:
     needs:

--- a/.github/workflows/sync-development.yml
+++ b/.github/workflows/sync-development.yml
@@ -29,3 +29,4 @@ jobs:
           PUBLISH_ENVIRONMENTS: development
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_ACTOR: ${{ github.actor }}
+          IS_ADHOC: 'true'


### PR DESCRIPTION
Adjusts the flows by making adhoc more specific and allow dev to receive auto deploys if no adhoc has occured

Depends of publish app pr https://github.com/ausaccessfed/publish_app/pull/115

This pull request includes several changes to the GitHub Actions and workflows to support an ad-hoc deployment environment. The most important changes involve adding a new input parameter `IS_ADHOC` and updating the workflow logic to handle this new parameter.

### Additions to GitHub Actions:

* [`.github/actions/publish_app/action.yaml`](diffhunk://#diff-5ac577f91adf73975275008fd05f8a58378bfbe0b746b2496739603a91bbbeecR25-R27): Added a new input parameter `IS_ADHOC` to override the provided `PUBLISH_ENVIRONMENTS` for ad-hoc deployments. (`[.github/actions/publish_app/action.yamlR25-R27](diffhunk://#diff-5ac577f91adf73975275008fd05f8a58378bfbe0b746b2496739603a91bbbeecR25-R27)`)
* [`.github/actions/publish_app/action.yaml`](diffhunk://#diff-5ac577f91adf73975275008fd05f8a58378bfbe0b746b2496739603a91bbbeecR57): Updated the `runs:` section to include the new `IS_ADHOC` parameter. (`[.github/actions/publish_app/action.yamlR57](diffhunk://#diff-5ac577f91adf73975275008fd05f8a58378bfbe0b746b2496739603a91bbbeecR57)`)

### Workflow Updates:

* [`.github/workflows/deploy-sync.yml`](diffhunk://#diff-b0049d19b83820b702b4d5431c1cf621df7e6a29e18e4bfd2141e323864952abL60-R64): Renamed `development_environments` to `adhoc_environments` and modified the default environments. (`[.github/workflows/deploy-sync.ymlL60-R64](diffhunk://#diff-b0049d19b83820b702b4d5431c1cf621df7e6a29e18e4bfd2141e323864952abL60-R64)`)
* [`.github/workflows/deploy-sync.yml`](diffhunk://#diff-b0049d19b83820b702b4d5431c1cf621df7e6a29e18e4bfd2141e323864952abL568-R576): Removed the job to update GitOps repo for test environments and modified the job for development environments to use `adhoc_environments` and the new `IS_ADHOC` parameter. (`[.github/workflows/deploy-sync.ymlL568-R576](diffhunk://#diff-b0049d19b83820b702b4d5431c1cf621df7e6a29e18e4bfd2141e323864952abL568-R576)`)
* [`.github/workflows/sync-development.yml`](diffhunk://#diff-0435cdf9738ab966e413404715a92ab0bef1dd0773257e9386a51c7746f67917R32): Added the `IS_ADHOC` parameter to the job for syncing the development environment. (`[.github/workflows/sync-development.ymlR32](diffhunk://#diff-0435cdf9738ab966e413404715a92ab0bef1dd0773257e9386a51c7746f67917R32)`)