### PR TITLE
Add slack notification when user starts a deployment to dev

### DIFF
--- a/.github/actions/alert_webhook/action.yaml
+++ b/.github/actions/alert_webhook/action.yaml
@@ -1,0 +1,17 @@
+name: 'Notify Webhook'
+description: 'A reusable action to notify a webhook with a custom message'
+inputs:
+  MESSAGE:
+    description: 'The message to send to the webhook'
+    required: true
+    default: 'Default message'
+  WEBHOOK_URL:
+    description: 'The URL of the webhook to notify'
+    required: true
+runs:
+  using: 'composite'
+  steps:
+    - name: Send notification to webhook
+      shell: bash
+      run: |
+        curl -X POST -H 'Content-type: application/json' --data "{\"text\":\"${{ inputs.message }}\"}" "${{ inputs.webhook_url }}"

--- a/.github/actions/notify_slack_webhook/action.yaml
+++ b/.github/actions/notify_slack_webhook/action.yaml
@@ -1,17 +1,17 @@
-name: 'Notify Webhook'
-description: 'A reusable action to notify a webhook with a custom message'
+name: 'Notify Slack Webhook'
+description: 'A reusable action to notify a slack webhook with a custom message'
 inputs:
   MESSAGE:
-    description: 'The message to send to the webhook'
+    description: 'The message to send to the slack webhook'
     required: true
     default: 'Default message'
   WEBHOOK_URL:
-    description: 'The URL of the webhook to notify'
+    description: 'The URL of the slack webhook to notify'
     required: true
 runs:
   using: 'composite'
   steps:
-    - name: Send notification to webhook
+    - name: Send notification to a slack webhook
       shell: bash
       run: |
         curl -X POST -H 'Content-type: application/json' --data "{\"text\":\"${{ inputs.message }}\"}" "${{ inputs.webhook_url }}"

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -90,6 +90,8 @@ on:
         required: true
       SNYK_TOKEN:
         required: true
+      SLACK_DEPLOYMENTS_WEBHOOK_URL:
+       required: true
 jobs:
   init:
     outputs:
@@ -154,6 +156,11 @@ jobs:
         with:
           BRANCH_NAME: ${{ steps.branch.outputs.BRANCH_NAME }}
         id: validate_issue_comment
+
+      - uses: ausaccessfed/workflows/.github/actions/alert_webhook@feature/add-slack-of-dev-deployments
+        with:
+          MESSAGE: "*${{ github.repository }}* is being deployed to development by *${{ github.actor }}* via *${{ github.sha }}*"
+          WEBHOOK_URL: ${{ secrets.SLACK_DEPLOYMENTS_WEBHOOK_URL }}
 
       - uses: ausaccessfed/workflows/.github/actions/init@main
         with:
@@ -642,6 +649,11 @@ jobs:
           targetUrl: ${{ steps.failure-check.outputs.ADHOC_URL }}
           description: ${{ steps.failure-check.outputs.ADHOC_OUTPUT }}
           context: 'Dev federation deploy'
+
+      - uses: ausaccessfed/workflows/.github/actions/alert_webhook@feature/add-slack-of-dev-deployments
+        with:
+          MESSAGE: "*${{ github.repository }}* has been deployed to development by *${{ github.actor }}* via *${{ github.sha }}*"
+          WEBHOOK_URL: ${{ secrets.SLACK_DEPLOYMENTS_WEBHOOK_URL }}
 
   finish:
     needs:

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -157,7 +157,8 @@ jobs:
           BRANCH_NAME: ${{ steps.branch.outputs.BRANCH_NAME }}
         id: validate_issue_comment
 
-      - uses: ausaccessfed/workflows/.github/actions/alert_webhook@feature/add-slack-of-dev-deployments
+      - uses: ausaccessfed/workflows/.github/actions/alert_webhook@main
+        if: needs.init.outputs.IS_SLASH_DEPLOY == 'true'
         with:
           MESSAGE: "*${{ github.repository }}* is being deployed to development by *${{ github.actor }}* via *${{ github.sha }}*"
           WEBHOOK_URL: ${{ secrets.SLACK_DEPLOYMENTS_WEBHOOK_URL }}
@@ -650,7 +651,8 @@ jobs:
           description: ${{ steps.failure-check.outputs.ADHOC_OUTPUT }}
           context: 'Dev federation deploy'
 
-      - uses: ausaccessfed/workflows/.github/actions/alert_webhook@feature/add-slack-of-dev-deployments
+      - uses: ausaccessfed/workflows/.github/actions/alert_webhook@main
+        if: needs.init.outputs.IS_SLASH_DEPLOY == 'true'
         with:
           MESSAGE: "*${{ github.repository }}* has been deployed to development by *${{ github.actor }}* via *${{ github.sha }}*"
           WEBHOOK_URL: ${{ secrets.SLACK_DEPLOYMENTS_WEBHOOK_URL }}


### PR DESCRIPTION
When a user triggers a new deployment with `/deploy` it will trigger a new webhook and post to the slack channel. Will remove the need to keep checking if anyone is using x app in dev:

![Screenshot 2024-10-28 at 1 07 20 pm](https://github.com/user-attachments/assets/676de31e-3059-4568-bc24-59196998be4f)

Once merged, will add all tech team users to the channel

