### PR TITLE
Fix conditional for initial /deploy slack webhook

### DIFF
--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -158,7 +158,7 @@ jobs:
         id: validate_issue_comment
 
       - uses: ausaccessfed/workflows/.github/actions/notify_slack_webhook@main
-        if: needs.init.outputs.IS_SLASH_DEPLOY == 'true'
+        if: inputs.event_name == 'issue_comment'
         with:
           MESSAGE: "*${{ github.repository }}* is being deployed to development by *${{ github.actor }}* via *${{ github.sha }}*"
           WEBHOOK_URL: ${{ secrets.SLACK_DEPLOYMENTS_WEBHOOK_URL }}


### PR DESCRIPTION
`needs.init.outputs.IS_SLASH_DEPLOY` is not yet available, instead use the same condition as the `validate-gpg-key` step
