### PR TITLE
make it exit if no image on last loop

### DIFF
--- a/.github/actions/publish_app/action.yaml
+++ b/.github/actions/publish_app/action.yaml
@@ -42,6 +42,10 @@ runs:
         for i in {1..5}; do
           aws ecr describe-images --repository-name "${{ inputs.ECR_REPOSITORY }}" \
             --image-ids imageTag=${{ inputs.PUBLISH_IMAGE_TAG }} && break
+          if [[ "$i" = "5" ]]; then
+            echo "No image found for tag ${{ inputs.PUBLISH_IMAGE_TAG }} in ECR repository ${{ inputs.ECR_REPOSITORY }}"
+            exit 1
+          fi
           sleep 120
         done
 


### PR DESCRIPTION
was causing unpublished images to be used as if they were published