### PR TITLE
Move dev slack notification to init block

### DIFF
--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -300,13 +300,11 @@ jobs:
             exit 1
           fi
 
-      - name: Notify Slack if development deploy
-        steps:
-          - uses: ausaccessfed/workflows/.github/actions/notify_slack_webhook@main
-            if: steps.env.outputs.IS_SLASH_DEPLOY == 'true'
-            with:
-              MESSAGE: '*${{ github.repository }}* is being deployed to development by *${{ github.actor }}* via *${{ github.sha }}*'
-              WEBHOOK_URL: ${{ secrets.SLACK_DEPLOYMENTS_WEBHOOK_URL }}
+      - uses: ausaccessfed/workflows/.github/actions/notify_slack_webhook@main
+        if: steps.env.outputs.IS_SLASH_DEPLOY == 'true'
+        with:
+          MESSAGE: '*${{ github.repository }}* is being deployed to development by *${{ github.actor }}* via *${{ github.sha }}*'
+          WEBHOOK_URL: ${{ secrets.SLACK_DEPLOYMENTS_WEBHOOK_URL }}
 
   build-test:
     needs: [init]

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -300,17 +300,13 @@ jobs:
             exit 1
           fi
 
-
-  notify-slack-if-dev-deploy:
-    needs: [init]
-    name: Notify Slack if development deploy
-    runs-on: ${{ needs.init.outputs.INTEL_RUNNER_CHEAP }}
-    steps:
-      - uses: ausaccessfed/workflows/.github/actions/notify_slack_webhook@main
-        if: needs.init.outputs.IS_SLASH_DEPLOY == 'true'
-        with:
-          MESSAGE: '*${{ github.repository }}* is being deployed to development by *${{ github.actor }}* via *${{ github.sha }}*'
-          WEBHOOK_URL: ${{ secrets.SLACK_DEPLOYMENTS_WEBHOOK_URL }}
+      - name: Notify Slack if development deploy
+        steps:
+          - uses: ausaccessfed/workflows/.github/actions/notify_slack_webhook@main
+            if: steps.env.outputs.IS_SLASH_DEPLOY == 'true'
+            with:
+              MESSAGE: '*${{ github.repository }}* is being deployed to development by *${{ github.actor }}* via *${{ github.sha }}*'
+              WEBHOOK_URL: ${{ secrets.SLACK_DEPLOYMENTS_WEBHOOK_URL }}
 
   build-test:
     needs: [init]


### PR DESCRIPTION
https://github.com/ausaccessfed/workflows/pull/472#discussion_r2006773237  requested it be in the init block to avoid spinning up another machine