### PR TITLE
Set commit status as failed if GPG checks fail

### DIFF
--- a/.github/actions/validate-gpg-key/action.yaml
+++ b/.github/actions/validate-gpg-key/action.yaml
@@ -7,6 +7,9 @@ inputs:
   CHECK_TRUSTED:
     description: 'Check if user is trusted'
     default: 'false'
+  HEAD_SHA:
+    description: 'head sha of commit that triggered this workflow'
+    default: ''
 runs:
   using: 'composite'
   steps:
@@ -41,3 +44,13 @@ runs:
         cp ../temp/verify_commit.sh verify_commit.sh
         cp -r ../temp/trusted_keys trusted_keys
         bash verify_commit.sh ${{ inputs.BRANCH_NAME }}
+
+    - name: Set commit status
+      if: steps.verify-commit.outcome == 'failure' && inputs.HEAD_SHA != ''
+      uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f
+      with:
+        sha: ${{ inputs.HEAD_SHA }}
+        token: ${{ secrets.GITHUB_TOKEN }}
+        status: failure
+        description: 'Verify Commit step failed'
+        context: 'GPG Key Validation'

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -159,17 +159,8 @@ jobs:
         if: inputs.event_name == 'issue_comment'
         with:
           BRANCH_NAME: ${{ steps.branch.outputs.BRANCH_NAME }}
+          HEAD_SHA: ${{ steps.comment-branch.outputs.HEAD_SHA }}
         id: validate_issue_comment
-
-      - name: Set commit status as failed if gpg key is not trusted
-        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f
-        if: validate_issue_comment.outcome == 'failure'
-        with:
-          sha: ${{ steps.comment-branch.outputs.HEAD_SHA }}
-          token: ${{ secrets.GITHUB_TOKEN }}
-          status: pending
-          description: 'Verify Commit step failed'
-          context: 'GPG Key Validation'
 
       - uses: ausaccessfed/workflows/.github/actions/init@main
         with:

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -161,6 +161,16 @@ jobs:
           BRANCH_NAME: ${{ steps.branch.outputs.BRANCH_NAME }}
         id: validate_issue_comment
 
+      - name: Set commit status as failed if gpg key is not trusted
+        uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f
+        if: validate_issue_comment.outcome == 'failure'
+        with:
+          sha: ${{ steps.comment-branch.outputs.HEAD_SHA }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          status: pending
+          description: 'Verify Commit step failed'
+          context: 'GPG Key Validation'
+
       - uses: ausaccessfed/workflows/.github/actions/init@main
         with:
           BRANCH_NAME: ${{ steps.branch.outputs.BRANCH_NAME }}


### PR DESCRIPTION
This can happen when a dev clicks on the ` merge master` changes on a GitHub branch and proceeds to type `/deploy`. The action will almost instantly fail, but the commit is left as `pending`. 

 I run into this one often with the renovate PRs and when I go to test them before merging

example, see https://github.com/ausaccessfed/federationmanager/pull/4811
![Screenshot 2025-03-21 at 2 38 25 pm](https://github.com/user-attachments/assets/b57b2331-afb0-4ec4-a7d5-dbce9f117521)
