### PR TITLE
Fix GPG check set commit status

### DIFF
--- a/.github/actions/validate-gpg-key/action.yaml
+++ b/.github/actions/validate-gpg-key/action.yaml
@@ -10,6 +10,7 @@ inputs:
   HEAD_SHA:
     description: 'head sha of commit that triggered this workflow'
     default: ''
+
 runs:
   using: 'composite'
   steps:
@@ -50,7 +51,7 @@ runs:
       uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f
       with:
         sha: ${{ inputs.HEAD_SHA }}
-        token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ github.token }}
         status: failure
         description: 'Verify Commit step failed'
         context: 'GPG Key Validation'

--- a/.github/actions/validate-gpg-key/action.yaml
+++ b/.github/actions/validate-gpg-key/action.yaml
@@ -10,6 +10,9 @@ inputs:
   HEAD_SHA:
     description: 'head sha of commit that triggered this workflow'
     default: ''
+  GITHUB_TOKEN:
+    description: 'github token used to auth to api'
+    default: ''
 
 runs:
   using: 'composite'
@@ -51,7 +54,7 @@ runs:
       uses: myrotvorets/set-commit-status-action@3730c0a348a2ace3c110851bed53331bc6406e9f
       with:
         sha: ${{ inputs.HEAD_SHA }}
-        token: ${{ github.token }}
+        token: ${{ inputs.GITHUB_TOKEN }}
         status: failure
         description: 'Verify Commit step failed'
         context: 'GPG Key Validation'

--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -160,6 +160,7 @@ jobs:
         with:
           BRANCH_NAME: ${{ steps.branch.outputs.BRANCH_NAME }}
           HEAD_SHA: ${{ steps.comment-branch.outputs.HEAD_SHA }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         id: validate_issue_comment
 
       - uses: ausaccessfed/workflows/.github/actions/init@main


### PR DESCRIPTION
secrets context is not available in actions, only workflows per https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/accessing-contextual-information-about-workflow-runs#context-availability