### PR TITLE
Add issue templates to the distributor workflow

### DIFF
--- a/.github/workflows/distributions/.github/ISSUE_TEMPLATE/1-enhancement.md
+++ b/.github/workflows/distributions/.github/ISSUE_TEMPLATE/1-enhancement.md
@@ -15,4 +15,4 @@ about: Software could be improved by adding, changing, or deleting features.
 
 ## Technical details
 
-<!-- A section for AAF developers to spitball implementation options and add links to relevant code and documentation. -->
+<!-- A section for AAF developers to propose implementation options and add links to relevant code and documentation. -->

--- a/.github/workflows/distributions/.github/ISSUE_TEMPLATE/1-enhancement.md
+++ b/.github/workflows/distributions/.github/ISSUE_TEMPLATE/1-enhancement.md
@@ -1,0 +1,18 @@
+---
+name: Enhancement
+about: Software could be improved by adding, changing, or deleting features.
+---
+
+<!-- Describe the proposed enhancement. Please add screenshots and links as applicable. -->
+
+## Value proposition
+
+<!-- Describe the benefit of this enhancement. -->
+
+## To resolve
+
+<!-- Define what it would mean for this work to be "done". -->
+
+## Technical details
+
+<!-- A section for AAF developers to spitball implementation options and add links to relevant code and documentation. -->

--- a/.github/workflows/distributions/.github/ISSUE_TEMPLATE/2-bug.md
+++ b/.github/workflows/distributions/.github/ISSUE_TEMPLATE/2-bug.md
@@ -23,4 +23,4 @@ labels: bug
 
 ## Technical details
 
-<!-- A section for AAF developers to spitball resolution options and add links to relevant code and documentation. -->
+<!-- A section for AAF developers to propose resolution options and add links to relevant code and documentation. -->

--- a/.github/workflows/distributions/.github/ISSUE_TEMPLATE/2-bug.md
+++ b/.github/workflows/distributions/.github/ISSUE_TEMPLATE/2-bug.md
@@ -1,0 +1,26 @@
+---
+name: Bug
+about: Software is wrong.
+labels: bug
+---
+
+<!-- Please add screenshots and links liberally. The more context we have, the easier it will be to fix the bug -->
+
+## What happened?
+
+## What should have happened?
+
+## Reproduction steps
+
+1. Go to '...'
+2. Click on '...'
+3. Scroll down to '...'
+4. See error
+
+## Additional context
+
+<!-- Add any other context about the problem here (e.g., network conditions, log dumps, related issues). -->
+
+## Technical details
+
+<!-- A section for AAF developers to spitball resolution options and add links to relevant code and documentation. -->

--- a/.github/workflows/distributions/.github/ISSUE_TEMPLATE/9-other.md
+++ b/.github/workflows/distributions/.github/ISSUE_TEMPLATE/9-other.md
@@ -1,0 +1,4 @@
+---
+name: Other
+about: Something which doesn't fit cleanly into other categories.
+---

--- a/.github/workflows/distributions/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/workflows/distributions/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: false # Should be redundant with 9-other.md


### PR DESCRIPTION
These are copied across from FMs repo, they are generic enough and I think would be valuable for other repos to have as well. Looking at the script, this might just work out of the box. Marking as a proposal as we might not want this. Please add thoughts as comments

The only repo I see that this might not be relevant for would be the dev-portal, as that has its own templates set up already

My thoughts:
- We are pushing for better issues with well scoped details so that any dev can action it
- Consolidates our repos, we can use the same forumula when creating issues, no matter which repo we are on