### PR TITLE
Fix commit status env var

### DIFF
--- a/.github/workflows/deploy-sync.yml
+++ b/.github/workflows/deploy-sync.yml
@@ -282,7 +282,7 @@ jobs:
           echo "INTEL_RUNNER_CHEAP=ubuntu-latest" >> $GITHUB_OUTPUT
           echo "ARM_RUNNER=arm64-${{inputs.runner_cores}}-cores" >> $GITHUB_OUTPUT
           echo "ARM_RUNNER_CHEAP=arm64-2-cores" >> $GITHUB_OUTPUT
-          echo "COMMIT_STATUS_CONTEXT_DEV_DEPLOY=${{env.COMMIT_STATUS_CONTEXT_DEV_DEPLOY}}" >> $GITHUB_OUTPUT
+          echo "COMMIT_STATUS_CONTEXT_DEV_DEPLOY=$COMMIT_STATUS_CONTEXT_DEV_DEPLOY" >> $GITHUB_OUTPUT
 
       - name: Check for diff
         if: inputs.force_up_to_date_contexts != '[]' && steps.env.outputs.SHOULD_PUSH_IMAGE_TO_ECR == 'false'


### PR DESCRIPTION
Per https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#defining-environment-variables-for-a-single-workflow the env var should be accessed using `$` instead

should fix:

<img width="527" alt="Screenshot 2025-03-25 at 9 42 29 am" src="https://github.com/user-attachments/assets/03d45705-d01d-46aa-a3a6-8b39869e50d8" />
