### PR TITLE
Dissallow console.logs

### DIFF
--- a/.github/workflows/distributions/eslint.config.js
+++ b/.github/workflows/distributions/eslint.config.js
@@ -1,5 +1,4 @@
 #PARTIAL#
-/* eslint-disable no-undef */
 const eslintPluginPrettierRecommended = require('eslint-plugin-prettier/recommended')
 const eslintPluginYml = require('eslint-plugin-yml')
 const eslint = require('@eslint/js')
@@ -27,6 +26,7 @@ const common = [
           props: false
         }
       ],
+      'no-console': ['error', { allow: ['warn', 'error'] }],
       'no-tabs': 'error',
       'no-plusplus': 'off',
       'no-underscore-dangle': 'off',
@@ -52,8 +52,7 @@ const common = [
         }
       ],
       'yml/no-empty-document': 'off'
-    },
-    settings: {}
+    }
   },
   {
     ignores: [
@@ -78,7 +77,8 @@ const common = [
       '**/values.yaml',
       '**/templates/',
       '.github/',
-      '.torba/'
+      '.torba/',
+      'eslint.configs.js'
     ]
   }
 ]


### PR DESCRIPTION
add eslint to ignore, there drift ona  few apps, add the console log rule

also exclude eslint from the lint, as we have some apps that override causing the distributions to fight

resolves https://github.com/ausaccessfed/federationmanager/issues/5194