### PR TITLE
Feature/allow workflow distributions to be auto merged

### DIFF
--- a/.github/workflows/pr-housekeeping.yml
+++ b/.github/workflows/pr-housekeeping.yml
@@ -4,7 +4,7 @@ on:
     inputs:
       AUTO_MERGEABLE_LABELS:
         type: string
-        default: 'development,test,devDependencies,testDependencies,dockerDependencies'
+        default: 'development,test,devDependencies,testDependencies,dockerDependencies,workflowDistribution'
     secrets:
       REPO_SCOPED_TOKEN:
         required: true

--- a/.github/workflows/todo-processor.yml
+++ b/.github/workflows/todo-processor.yml
@@ -23,5 +23,6 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_PRIVATE_KEY: ${{ secrets.RENOVATE_GPG_PRIVATE_KEY }}
+        env:
           MANUAL_COMMIT_REF: ${{ inputs.MANUAL_COMMIT_REF }}
           MANUAL_BASE_REF: ${{ inputs.MANUAL_BASE_REF }}

--- a/scripts/workflow-distributor.js
+++ b/scripts/workflow-distributor.js
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 const CONSTANTS = {
   regex: {
     once: /#ONCE#(\n)*/,
@@ -376,7 +377,8 @@ const createPR = async ({ repo, tree, baseBranch }) => {
       head: CONSTANTS.prBranchName,
       base: baseBranch,
       title: message,
-      body: message
+      body: message,
+      labels: ['workflowDistribution']
     })
   }
 


### PR DESCRIPTION
cause were lazy, 

If they were to cause issues we should have ci actions in each repo that blocks their auto merging