### PR TITLE
Reduce VS Code extension recommendations

### DIFF
--- a/.github/workflows/distributions/.vscode/extensions.json
+++ b/.github/workflows/distributions/.vscode/extensions.json
@@ -46,7 +46,6 @@
     "kisstkondoros.vscode-gutter-preview",
     "christian-kohler.path-intellisense",
     "alefragnani.project-manager",
-    "cssho.vscode-svgviewer",
     "wayou.vscode-todo-highlight",
     "aaron-bond.better-comments",
     "tomoki1207.pdf",

--- a/.github/workflows/distributions/.vscode/extensions.json
+++ b/.github/workflows/distributions/.vscode/extensions.json
@@ -20,7 +20,6 @@
     "christian-kohler.npm-intellisense",
 
     // linting
-    "dbaeumer.vscode-eslint",
     "rvest.vs-code-prettier-eslint",
 
     //jinja

--- a/.github/workflows/distributions/.vscode/extensions.json
+++ b/.github/workflows/distributions/.vscode/extensions.json
@@ -6,7 +6,6 @@
     "formulahendry.auto-rename-tag",
     "ecmel.vscode-html-css",
     "redhat.vscode-xml",
-    "redhat.vscode-yaml",
 
     // shell
     "foxundermoon.shell-format",

--- a/.github/workflows/distributions/.vscode/extensions.json
+++ b/.github/workflows/distributions/.vscode/extensions.json
@@ -52,7 +52,6 @@
     "cssho.vscode-svgviewer",
     "wayou.vscode-todo-highlight",
     "aaron-bond.better-comments",
-    "vscode-icons-team.vscode-icons",
     "tomoki1207.pdf",
 
     //test

--- a/.github/workflows/distributions/.vscode/extensions.json
+++ b/.github/workflows/distributions/.vscode/extensions.json
@@ -7,9 +7,6 @@
     "ecmel.vscode-html-css",
     "redhat.vscode-xml",
 
-    // shell
-    "foxundermoon.shell-format",
-
     // css
     "mrmlnc.vscode-scss",
     "stylelint.vscode-stylelint",

--- a/.github/workflows/distributions/.vscode/extensions.json
+++ b/.github/workflows/distributions/.vscode/extensions.json
@@ -36,9 +36,6 @@
     // coverage
     "ryanluker.vscode-coverage-gutters",
 
-    //env
-    "mikestead.dotenv",
-
     // ruby
     "rubocop.vscode-rubocop",
     "Shopify.ruby-lsp",

--- a/.github/workflows/distributions/.vscode/extensions.json
+++ b/.github/workflows/distributions/.vscode/extensions.json
@@ -34,7 +34,6 @@
     // random
     "kisstkondoros.vscode-gutter-preview",
     "christian-kohler.path-intellisense",
-    "wayou.vscode-todo-highlight",
     "aaron-bond.better-comments",
 
     //test

--- a/.github/workflows/distributions/.vscode/extensions.json
+++ b/.github/workflows/distributions/.vscode/extensions.json
@@ -60,7 +60,6 @@
 
     // git
     "qezhu.gitlink",
-    "eamodio.gitlens",
 
     // terraform
     "hashicorp.terraform",

--- a/.github/workflows/distributions/.vscode/extensions.json
+++ b/.github/workflows/distributions/.vscode/extensions.json
@@ -11,7 +11,6 @@
     "mrmlnc.vscode-scss",
 
     // js
-    "steoates.autoimport",
     "mgmcdermott.vscode-language-babel",
     "dbaeumer.vscode-eslint",
     "Orta.vscode-jest",

--- a/.github/workflows/distributions/.vscode/extensions.json
+++ b/.github/workflows/distributions/.vscode/extensions.json
@@ -9,7 +9,6 @@
 
     // css
     "mrmlnc.vscode-scss",
-    "stylelint.vscode-stylelint",
 
     // js
     "steoates.autoimport",

--- a/.github/workflows/distributions/.vscode/extensions.json
+++ b/.github/workflows/distributions/.vscode/extensions.json
@@ -1,7 +1,6 @@
 {
   "recommendations": [
     //html
-    "formulahendry.auto-close-tag",
     "ecmel.vscode-html-css",
     "redhat.vscode-xml",
 

--- a/.github/workflows/distributions/.vscode/extensions.json
+++ b/.github/workflows/distributions/.vscode/extensions.json
@@ -32,13 +32,10 @@
     "KoichiSasada.vscode-rdbg",
 
     // random
-    "ue.alphabetical-sorter",
     "kisstkondoros.vscode-gutter-preview",
     "christian-kohler.path-intellisense",
-    "alefragnani.project-manager",
     "wayou.vscode-todo-highlight",
     "aaron-bond.better-comments",
-    "tomoki1207.pdf",
 
     //test
     "ms-vscode.test-adapter-converter",

--- a/.github/workflows/distributions/.vscode/extensions.json
+++ b/.github/workflows/distributions/.vscode/extensions.json
@@ -74,7 +74,6 @@
     // markdown
     "yzhang.markdown-all-in-one",
     "bierner.markdown-mermaid",
-    "DavidAnson.vscode-markdownlint",
 
     // sql
     "dorzey.vscode-sqlfluff"

--- a/.github/workflows/distributions/.vscode/extensions.json
+++ b/.github/workflows/distributions/.vscode/extensions.json
@@ -39,9 +39,6 @@
     //env
     "mikestead.dotenv",
 
-    // editorconfig
-    "EditorConfig.EditorConfig",
-
     // ruby
     "rubocop.vscode-rubocop",
     "Shopify.ruby-lsp",
@@ -65,11 +62,8 @@
 
     //github
     "github.vscode-github-actions",
-    "GitHub.copilot",
-    "GitHub.copilot-chat",
 
     // git
-    "codezombiech.gitignore",
     "qezhu.gitlink",
     "eamodio.gitlens",
 

--- a/.github/workflows/distributions/.vscode/extensions.json
+++ b/.github/workflows/distributions/.vscode/extensions.json
@@ -2,8 +2,6 @@
   "recommendations": [
     //html
     "formulahendry.auto-close-tag",
-    "formulahendry.auto-complete-tag",
-    "formulahendry.auto-rename-tag",
     "ecmel.vscode-html-css",
     "redhat.vscode-xml",
 


### PR DESCRIPTION
Reasons applicable to ALL removals are:

- overhead from installing/patching/deprecating
- overwhelm for new devs

Otherwise, see commits for individual reasons for not recommending these.

## Future

I'm still suspect of many of remaining extensions, but will take the time to investigate them while doing some feature work in VS Code.