### PR TITLE
Tweak extensions again

### DIFF
--- a/.github/workflows/distributions/.vscode/extensions.json
+++ b/.github/workflows/distributions/.vscode/extensions.json
@@ -27,7 +27,6 @@
     "ryanluker.vscode-coverage-gutters",
 
     // ruby
-    "rubocop.vscode-rubocop",
     "Shopify.ruby-lsp",
     "KoichiSasada.vscode-rdbg",
 

--- a/.github/workflows/distributions/.vscode/extensions.json
+++ b/.github/workflows/distributions/.vscode/extensions.json
@@ -42,10 +42,8 @@
     "connorshea.vscode-ruby-test-adapter",
 
     //github
+    "github.vscode-pull-request-github",
     "github.vscode-github-actions",
-
-    // git
-    "qezhu.gitlink",
 
     // terraform
     "hashicorp.terraform",

--- a/.github/workflows/distributions/.vscode/extensions.json
+++ b/.github/workflows/distributions/.vscode/extensions.json
@@ -36,11 +36,6 @@
     "christian-kohler.path-intellisense",
     "aaron-bond.better-comments",
 
-    //test
-    "ms-vscode.test-adapter-converter",
-    "hbenl.vscode-test-explorer",
-    "connorshea.vscode-ruby-test-adapter",
-
     //github
     "github.vscode-pull-request-github",
     "github.vscode-github-actions",


### PR DESCRIPTION
## Recommend first-party GH extension, don't recommend gitlink

The first-party GH extension does some useful stuff, including providing the same functionality that gitlink does.

## Remove superseded test extensions

Experience is good with just Ruby LSP and vanilla VS Code. That hasn't always been the case, but it is now.


https://github.com/user-attachments/assets/29373754-a81b-40c9-9f4b-03adc6945cfc

<img width="1022" height="611" alt="Screenshot 2025-08-18 at 12 41 32 pm" src="https://github.com/user-attachments/assets/bb7f613f-a59a-45a4-8350-522caf3411b1" />


So, we don't need to recommend all these extensions anymore.

## Don't recommend separate rubocop extension
 
Since `rubocop` `1.70`, `ruby-lsp` automatically integrates `rubocop`. There's no need for a separate extension. We run `1.70` in FM and Rapid IdP Manager, and should be able to upgrade easily enough in the microservice repos.

Each separate extension incurs a fair bit of overhead as they each need to parse etc. the code to build an internal representation. So, most devs will be better off only using `ruby-lsp`.