### PR TITLE
Don't recommend extra terraform extension

### DIFF
--- a/.github/workflows/distributions/.vscode/extensions.json
+++ b/.github/workflows/distributions/.vscode/extensions.json
@@ -41,7 +41,6 @@
 
     // terraform
     "hashicorp.terraform",
-    "4ops.terraform",
 
     //helm
     "Tim-Koehler.helm-intellisense",


### PR DESCRIPTION
From my testing, the first-party extension is sufficient for our cases.

Part of #438.